### PR TITLE
fifo-transmit: disallow duplicate fifo paths

### DIFF
--- a/gaeguli/fifo-transmit.c
+++ b/gaeguli/fifo-transmit.c
@@ -202,7 +202,7 @@ gaeguli_fifo_transmit_init (GaeguliFifoTransmit * self)
       (GDestroyNotify) g_free, (GDestroyNotify) srt_info_unref);
 }
 
-static GaeguliFifoTransmit *
+GaeguliFifoTransmit *
 gaeguli_fifo_transmit_new_full (const gchar * tmpdir)
 {
 

--- a/gaeguli/fifo-transmit.c
+++ b/gaeguli/fifo-transmit.c
@@ -52,6 +52,7 @@ srt_info_new (const gchar * host, guint port, GaeguliSRTMode mode,
   return info;
 }
 
+#if 0
 static SRTInfo *
 srt_info_ref (SRTInfo * info)
 {
@@ -63,6 +64,7 @@ srt_info_ref (SRTInfo * info)
 
   return info;
 }
+#endif
 
 static void
 srt_info_unref (SRTInfo * info)

--- a/gaeguli/fifo-transmit.h
+++ b/gaeguli/fifo-transmit.h
@@ -22,6 +22,8 @@ G_DECLARE_FINAL_TYPE                   (GaeguliFifoTransmit, gaeguli_fifo_transm
 
 GaeguliFifoTransmit    *gaeguli_fifo_transmit_new      (void);
 
+GaeguliFifoTransmit    *gaeguli_fifo_transmit_new_full (const gchar            *tmpdir);
+
 const gchar            *gaeguli_fifo_transmit_get_fifo (GaeguliFifoTransmit    *self);
 
 guint                   gaeguli_fifo_transmit_start    (GaeguliFifoTransmit    *self,

--- a/tests/test-fifo-transmit.c
+++ b/tests/test-fifo-transmit.c
@@ -9,6 +9,7 @@
 
 #include <gaeguli/gaeguli.h>
 #include <gaeguli/fifo-transmit.h>
+#include <glib/gstdio.h>
 
 typedef struct _TestFixture
 {
@@ -58,6 +59,24 @@ test_gaeguli_fifo_transmit_start (TestFixture * fixture, gconstpointer unused)
           &error));
 }
 
+static void
+test_gaeguli_fifo_transmit_same_fifo_path ()
+{
+  g_autoptr (GaeguliFifoTransmit) fifo_transmit_1 = NULL;
+  g_autoptr (GaeguliFifoTransmit) fifo_transmit_2 = NULL;
+  g_autofree gchar *tmpdir = NULL;
+
+  tmpdir =
+      g_build_filename (g_get_tmp_dir (), "test-gaeguli-fifo-XXXXXX", NULL);
+  g_mkdtemp (tmpdir);
+
+  fifo_transmit_1 = gaeguli_fifo_transmit_new_full (tmpdir);
+  g_assert_nonnull (fifo_transmit_1);
+
+  fifo_transmit_2 = gaeguli_fifo_transmit_new_full (tmpdir);
+  g_assert_null (fifo_transmit_2);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -69,6 +88,9 @@ main (int argc, char *argv[])
   g_test_add ("/gaeguli/fifo-transmit-start",
       TestFixture, NULL, fixture_setup,
       test_gaeguli_fifo_transmit_start, fixture_teardown);
+
+  g_test_add_func ("/gaeguli/fifo-transmit-same-fifo-path",
+      test_gaeguli_fifo_transmit_same_fifo_path);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Make sure two GaeguliFifoTransmit instances can't share the same fifo path.