### PR TITLE
fifo-transmit: fix _recv_stream called after freeing GaeguliFifoTransmit

### DIFF
--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -76,6 +76,7 @@ link_target_new (GaeguliPipeline * self, GstElement * src, guint target_id,
   return t;
 }
 
+#if 0
 static LinkTarget *
 link_target_ref (LinkTarget * link_target)
 {
@@ -88,6 +89,7 @@ link_target_ref (LinkTarget * link_target)
 
   return link_target;
 }
+#endif
 
 static void
 link_target_unref (LinkTarget * link_target)

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -420,7 +420,7 @@ _link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
 
     g_hash_table_remove (link_target->self->targets,
         GINT_TO_POINTER (link_target->target_id));
-    g_idle_add (_stop_pipeline, self);
+    g_idle_add ((GSourceFunc) _stop_pipeline, self);
   }
 
   return GST_PAD_PROBE_REMOVE;

--- a/tests/test-pipeline.c
+++ b/tests/test-pipeline.c
@@ -52,7 +52,7 @@ _stream_stopped_cb (GaeguliPipeline * pipeline, guint target_id,
 {
   g_debug ("got stopped signal %x", target_id);
 
-  g_timeout_add (100, _quit_loop, fixture);
+  g_timeout_add (100, (GSourceFunc) _quit_loop, fixture);
 }
 
 static void


### PR DESCRIPTION
GSource created with g_io_add_watch() when starting fifo transmit was holding the last reference to our IO channel and keeping it alive even after GaeguliFifoTransmit got disposed.

Since we don't touch the IO channel after we create it, give up our reference and delete it by removing the event source.