### PR TITLE
Add fifo-transmit-add-remove-random test

### DIFF
--- a/gaeguli/fifo-transmit.c
+++ b/gaeguli/fifo-transmit.c
@@ -120,6 +120,8 @@ struct _GaeguliFifoTransmit
   GHashTable *sockets;
 
   gchar buf[BUFSIZE];
+
+  GaeguliFifoTransmitStats stats;
 };
 
 /* *INDENT-OFF* */
@@ -273,6 +275,14 @@ gaeguli_fifo_transmit_get_read_status (GaeguliFifoTransmit * self)
   return status;
 }
 
+GaeguliFifoTransmitStats *
+gaeguli_fifo_transmit_get_stats (GaeguliFifoTransmit * self)
+{
+  g_return_val_if_fail (GAEGULI_IS_FIFO_TRANSMIT (self), NULL);
+
+  return &self->stats;
+}
+
 static gboolean
 _srt_open (SRTInfo * info)
 {
@@ -424,6 +434,8 @@ _recv_stream (GIOChannel * channel, GIOCondition cond, gpointer user_data)
     if (self->fifo_read_status != G_IO_STATUS_NORMAL && error != NULL) {
       g_error ("%s", error->message);
     }
+
+    self->stats.bytes_read += read_len;
 
     _send_to (self, self->buf, read_len);
   }

--- a/gaeguli/fifo-transmit.h
+++ b/gaeguli/fifo-transmit.h
@@ -16,6 +16,11 @@
 
 G_BEGIN_DECLS
 
+typedef struct
+{
+  gsize bytes_read;
+} GaeguliFifoTransmitStats;
+
 #define GAEGULI_TYPE_FIFO_TRANSMIT     (gaeguli_fifo_transmit_get_type ())
 G_DECLARE_FINAL_TYPE                   (GaeguliFifoTransmit, gaeguli_fifo_transmit,
                                         GAEGULI, FIFO_TRANSMIT, GObject)
@@ -28,6 +33,10 @@ const gchar            *gaeguli_fifo_transmit_get_fifo (GaeguliFifoTransmit    *
 
 GIOStatus               gaeguli_fifo_transmit_get_read_status
                                                        (GaeguliFifoTransmit *self);
+
+GaeguliFifoTransmitStats
+                       *gaeguli_fifo_transmit_get_stats
+                                                       (GaeguliFifoTransmit    *self);
 
 guint                   gaeguli_fifo_transmit_start    (GaeguliFifoTransmit    *self,
                                                         const gchar            *host,

--- a/gaeguli/fifo-transmit.h
+++ b/gaeguli/fifo-transmit.h
@@ -26,6 +26,9 @@ GaeguliFifoTransmit    *gaeguli_fifo_transmit_new_full (const gchar            *
 
 const gchar            *gaeguli_fifo_transmit_get_fifo (GaeguliFifoTransmit    *self);
 
+GIOStatus               gaeguli_fifo_transmit_get_read_status
+                                                       (GaeguliFifoTransmit *self);
+
 guint                   gaeguli_fifo_transmit_start    (GaeguliFifoTransmit    *self,
                                                         const gchar            *host,
                                                         guint                   port,

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -22,7 +22,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GEnumClass, g_type_class_unref)
 #endif
 /* *INDENT-ON* */
 
-#define GAEGULI_PIPELINE_VSRC_STR       "%s %s%s ! video/x-raw,width=%d,height=%d ! tee name=tee "
+#define GAEGULI_PIPELINE_VSRC_STR       "%s %s%s ! video/x-raw,width=%d,height=%d ! tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc tune=zerolatency ! \
@@ -347,6 +347,8 @@ _build_vsrc_pipeline (GaeguliPipeline * self, GaeguliVideoResolution resolution,
   self->pipeline = gst_pipeline_new (NULL);
   gst_bin_add (GST_BIN (self->pipeline), g_object_ref (self->vsrc));
 
+  gst_element_set_state (self->pipeline, GST_STATE_PLAYING);
+
   return TRUE;
 
 failed:
@@ -497,8 +499,6 @@ gaeguli_pipeline_add_fifo_target_full (GaeguliPipeline * self,
 
     gst_pad_add_probe (tee_srcpad, GST_PAD_PROBE_TYPE_BLOCK, _link_probe_cb,
         g_steal_pointer (&link_target), (GDestroyNotify) link_target_unref);
-
-    gst_element_set_state (self->pipeline, GST_STATE_PLAYING);
   }
 
   return target_id;

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -393,6 +393,7 @@ _link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
     if (tee_ghost_pad == NULL) {
       g_error ("ghost pad is null");
     }
+    gst_element_sync_state_with_parent (link_target->target);
     if (gst_pad_link (tee_ghost_pad, sink_pad) != GST_PAD_LINK_OK) {
       g_error ("failed to link tee src to target sink");
     }

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -423,8 +423,8 @@ _link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
     gst_ghost_pad_set_target (GST_GHOST_PAD (ghost_srcpad), NULL);
     gst_element_remove_pad (link_target->self->vsrc, ghost_srcpad);
     gst_element_release_request_pad (tee, srcpad);
-    gst_element_set_state (link_target->target, GST_STATE_NULL);
     gst_bin_remove (GST_BIN (link_target->self->pipeline), link_target->target);
+    gst_element_set_state (link_target->target, GST_STATE_NULL);
 
     g_signal_emit (self, signals[SIG_STREAM_STOPPED], 0,
         link_target->target_id);

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -377,6 +377,8 @@ _link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
   g_autoptr (GstPad) sink_pad = NULL;
   g_autoptr (GaeguliPipeline) self = g_object_ref (link_target->self);
 
+  gst_pad_remove_probe (pad, info->id);
+
   if (link_target->link) {
     GstPad *tee_ghost_pad = NULL;
 
@@ -493,7 +495,7 @@ gaeguli_pipeline_add_fifo_target_full (GaeguliPipeline * self,
     link_target =
         link_target_new (self, self->vsrc, target_id, target_pipeline, TRUE);
 
-    gst_pad_add_probe (tee_srcpad, GST_PAD_PROBE_TYPE_IDLE, _link_probe_cb,
+    gst_pad_add_probe (tee_srcpad, GST_PAD_PROBE_TYPE_BLOCK, _link_probe_cb,
         g_steal_pointer (&link_target), (GDestroyNotify) link_target_unref);
 
     gst_element_set_state (self->pipeline, GST_STATE_PLAYING);
@@ -544,7 +546,7 @@ gaeguli_pipeline_remove_target (GaeguliPipeline * self, guint target_id,
   link_target =
       link_target_new (self, self->vsrc, target_id, target_pipeline, FALSE);
 
-  gst_pad_add_probe (tee_srcpad, GST_PAD_PROBE_TYPE_IDLE, _link_probe_cb,
+  gst_pad_add_probe (tee_srcpad, GST_PAD_PROBE_TYPE_BLOCK, _link_probe_cb,
       g_steal_pointer (&link_target), (GDestroyNotify) link_target_unref);
 
 

--- a/tests/test-fifo-transmit.c
+++ b/tests/test-fifo-transmit.c
@@ -10,6 +10,9 @@
 #include <gaeguli/gaeguli.h>
 #include <gaeguli/fifo-transmit.h>
 #include <glib/gstdio.h>
+#include <gst/gst.h>
+
+#define FIFO_READ_LIMIT_BYTES 10000
 
 typedef struct _TestFixture
 {
@@ -77,10 +80,156 @@ test_gaeguli_fifo_transmit_same_fifo_path ()
   g_assert_null (fifo_transmit_2);
 }
 
+typedef struct
+{
+  GaeguliFifoTransmit *transmit;
+  guint transmit_id;
+  guint target_id;
+  gboolean closing;
+} FifoTestData;
+
+typedef struct
+{
+  GMutex lock;
+  TestFixture *fixture;
+  GaeguliPipeline *pipeline;
+  FifoTestData fifos[5];
+  guint fifos_to_create;
+} AddRemoveTestData;
+
+static gboolean
+add_remove_fifo_cb (AddRemoveTestData * data)
+{
+  gint i;
+
+  g_mutex_lock (&data->lock);
+
+  /* If there's a free slot, create a new fifo transmit. */
+  for (i = 0; data->fifos_to_create && i != G_N_ELEMENTS (data->fifos); ++i) {
+    FifoTestData *fifo = &data->fifos[i];
+
+    if (fifo->transmit == NULL && !fifo->closing) {
+      g_autoptr (GError) error = NULL;
+
+      fifo->transmit = gaeguli_fifo_transmit_new ();
+      g_assert_nonnull (fifo->transmit);
+
+      fifo->transmit_id = gaeguli_fifo_transmit_start (fifo->transmit,
+          "127.0.0.1", 8888, GAEGULI_SRT_MODE_CALLER, &error);
+      g_assert_no_error (error);
+
+      fifo->target_id = gaeguli_pipeline_add_fifo_target_full (data->pipeline,
+          GAEGULI_VIDEO_CODEC_H264, GAEGULI_VIDEO_RESOLUTION_640x480,
+          gaeguli_fifo_transmit_get_fifo (fifo->transmit), &error);
+      g_assert_no_error (error);
+
+      g_debug ("Added fifo %u", fifo->transmit_id);
+
+      --data->fifos_to_create;
+      break;
+    }
+  }
+
+  /* Check that all fifos are in NORMAL state and data are being read. */
+  for (i = 0; i != G_N_ELEMENTS (data->fifos); ++i) {
+    FifoTestData *fifo = &data->fifos[i];
+    GaeguliFifoTransmitStats *stats;
+    g_autoptr (GError) error = NULL;
+
+    if (fifo->transmit == NULL || fifo->closing) {
+      continue;
+    }
+
+    g_assert_cmpint (gaeguli_fifo_transmit_get_read_status (fifo->transmit), ==,
+        G_IO_STATUS_NORMAL);
+
+    stats = gaeguli_fifo_transmit_get_stats (fifo->transmit);
+    g_assert_nonnull (stats);
+
+    g_debug ("Fifo %u has read %lu B", fifo->transmit_id, stats->bytes_read);
+
+    /* Remove fifos that have read at least FIFO_READ_LIMIT_BYTES. */
+    if (stats->bytes_read >= FIFO_READ_LIMIT_BYTES) {
+      /* First stop the pipeline. */
+      gaeguli_pipeline_remove_target (data->pipeline, fifo->target_id, &error);
+      g_assert_no_error (error);
+
+      fifo->closing = TRUE;
+      /* The removal gets finished in stream_stopped_cb(). */
+    }
+  }
+
+  g_mutex_unlock (&data->lock);
+
+  return G_SOURCE_CONTINUE;
+}
+
+static void
+stream_stopped_cb (GaeguliPipeline * pipeline, guint target_id,
+    AddRemoveTestData * data)
+{
+  gint i;
+  gboolean have_active_fifos = FALSE;
+
+  g_mutex_lock (&data->lock);
+
+  for (i = 0; i != G_N_ELEMENTS (data->fifos); ++i) {
+    FifoTestData *fifo = &data->fifos[i];
+    g_autoptr (GError) error = NULL;
+
+    if (fifo->target_id == target_id) {
+      g_assert_true (fifo->closing);
+      gaeguli_fifo_transmit_stop (fifo->transmit, fifo->transmit_id, &error);
+      g_assert_no_error (error);
+      g_clear_object (&fifo->transmit);
+      fifo->closing = FALSE;
+
+      g_debug ("Removed fifo %u", fifo->target_id);
+    } else if (fifo->transmit != NULL) {
+      have_active_fifos = TRUE;
+    }
+  }
+
+  if (!have_active_fifos && data->fifos_to_create == 0) {
+    /* All fifos finished receiving, quit the test. */
+    g_main_loop_quit (data->fixture->loop);
+  }
+
+  g_mutex_unlock (&data->lock);
+}
+
+static void
+test_gaeguli_fifo_transmit_add_remove_random (TestFixture * fixture,
+    gconstpointer unused)
+{
+  AddRemoveTestData data = { 0 };
+  gint i;
+
+  g_mutex_init (&data.lock);
+  data.fixture = fixture;
+  data.pipeline = gaeguli_pipeline_new ();
+  data.fifos_to_create = 10;
+
+  g_signal_connect (data.pipeline, "stream-stopped",
+      (GCallback) stream_stopped_cb, &data);
+
+  g_timeout_add (20, (GSourceFunc) add_remove_fifo_cb, &data);
+  g_main_loop_run (fixture->loop);
+
+  g_clear_object (&data.pipeline);
+  for (i = 0; i != G_N_ELEMENTS (data.fifos); ++i) {
+    g_clear_object (&data.fifos[i].transmit);
+  }
+}
+
 int
 main (int argc, char *argv[])
 {
   g_test_init (&argc, &argv, NULL);
+  /* Don't treat warnings as fatal, which is GTest default. */
+  g_log_set_always_fatal (G_LOG_FATAL_MASK | G_LOG_LEVEL_CRITICAL);
+
+  gst_init (&argc, &argv);
 
   g_test_add_func ("/gaeguli/fifo-transmit-instance",
       test_gaeguli_fifo_transmit_instance);
@@ -91,6 +240,10 @@ main (int argc, char *argv[])
 
   g_test_add_func ("/gaeguli/fifo-transmit-same-fifo-path",
       test_gaeguli_fifo_transmit_same_fifo_path);
+
+  g_test_add ("/gaeguli/fifo-transmit-add-remove-random",
+      TestFixture, NULL, fixture_setup,
+      test_gaeguli_fifo_transmit_add_remove_random, fixture_teardown);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Covers T16540 test cases 2 to 4.

It creates 10 fifo transmits in total, each at a different time. The fifos connect to a common webcam source, read at least 10000 bytes of data and disconnect again.

Checks whether random linking and unliking of target pipelines to the video source tee works without breaking the already connected streams.