### PR TITLE
Add fifo-transmit-reattach-stream test

### DIFF
--- a/gaeguli/fifo-transmit.h
+++ b/gaeguli/fifo-transmit.h
@@ -29,6 +29,9 @@ const gchar            *gaeguli_fifo_transmit_get_fifo (GaeguliFifoTransmit    *
 GIOStatus               gaeguli_fifo_transmit_get_read_status
                                                        (GaeguliFifoTransmit *self);
 
+gssize                  gaeguli_fifo_transmit_get_available_bytes
+                                                       (GaeguliFifoTransmit *self);
+
 GVariantDict           *gaeguli_fifo_transmit_get_stats
                                                        (GaeguliFifoTransmit    *self);
 

--- a/gaeguli/pipeline.h
+++ b/gaeguli/pipeline.h
@@ -38,6 +38,9 @@ GaeguliReturn           gaeguli_pipeline_remove_target
                                                 (GaeguliPipeline       *self,
                                                  guint                  target_id,
                                                  GError               **error);
+
+void                    gaeguli_pipeline_stop   (GaeguliPipeline       *self);
+
 G_END_DECLS
 
 #endif // __GAEGULI_PIPELINE_H__

--- a/tests/test-fifo-transmit.c
+++ b/tests/test-fifo-transmit.c
@@ -230,6 +230,97 @@ test_gaeguli_fifo_transmit_add_remove_random (TestFixture * fixture,
   }
 }
 
+static void
+reattach_stream_stream_stopped_cb (GaeguliPipeline * pipeline, guint target_id,
+    gboolean * flag)
+{
+  *flag = TRUE;
+}
+
+static gsize
+get_bytes_read (GaeguliFifoTransmit * transmit)
+{
+  g_autoptr (GVariantDict) stats = NULL;
+  g_autoptr (GVariant) bytes_read = NULL;
+
+  stats = gaeguli_fifo_transmit_get_stats (transmit);
+  g_assert_nonnull (stats);
+  bytes_read = g_variant_dict_lookup_value (stats, "bytes-read",
+      G_VARIANT_TYPE_UINT64);
+  g_assert_nonnull (bytes_read);
+
+  return g_variant_get_uint64 (bytes_read);
+}
+
+static gsize
+read_from_pipeline (GaeguliFifoTransmit * transmit, gsize bytes_read_limit)
+{
+  g_autoptr (GaeguliPipeline) pipeline = NULL;
+  g_autoptr (GError) error = NULL;
+  gboolean stream_stopped = FALSE;
+  guint target_id;
+  gsize bytes_read;
+
+  /* Set up a pipeline. */
+  pipeline = gaeguli_pipeline_new ();
+  target_id = gaeguli_pipeline_add_fifo_target_full (pipeline,
+      GAEGULI_VIDEO_CODEC_H264, GAEGULI_VIDEO_RESOLUTION_640x480,
+      gaeguli_fifo_transmit_get_fifo (transmit), &error);
+  g_assert_no_error (error);
+
+  g_debug ("Started reading from pipeline %p", pipeline);
+
+  /* Read from the fifo until we reach the desired limit. */
+  do {
+    g_main_context_iteration (g_main_context_get_thread_default (), FALSE);
+
+    bytes_read = get_bytes_read (transmit);
+    g_debug ("Fifo has read %lu B", bytes_read);
+  } while (bytes_read < bytes_read_limit);
+
+  /* Detach the pipeline from our fifo transmit. */
+  gaeguli_pipeline_remove_target (pipeline, target_id, &error);
+  g_assert_no_error (error);
+
+  /* Wait until the pipeline stops. */
+  g_signal_connect (pipeline, "stream-stopped",
+      (GCallback) reattach_stream_stream_stopped_cb, &stream_stopped);
+  while (!stream_stopped) {
+    g_main_context_iteration (g_main_context_get_thread_default (), FALSE);
+    g_debug ("Status: %d", gaeguli_fifo_transmit_get_read_status (transmit));
+  }
+
+  gaeguli_pipeline_stop (pipeline);
+
+  /* Read any data remaining in the pipe before attaching the next pipeline. */
+  while (gaeguli_fifo_transmit_get_available_bytes (transmit) > 0) {
+    g_main_context_iteration (g_main_context_get_thread_default (), FALSE);
+  }
+
+  return get_bytes_read (transmit);
+}
+
+static void
+test_gaeguli_fifo_transmit_reattach_stream (TestFixture * fixture,
+    gconstpointer unused)
+{
+  g_autoptr (GaeguliFifoTransmit) transmit = gaeguli_fifo_transmit_new ();
+  g_autoptr (GError) error = NULL;
+  gssize bytes_read;
+
+  g_main_context_push_thread_default (g_main_loop_get_context (fixture->loop));
+
+  gaeguli_fifo_transmit_start (transmit, "127.0.0.1", 8888,
+      GAEGULI_SRT_MODE_CALLER, &error);
+  g_assert_no_error (error);
+
+  /* Let two different pipelines write consecutively into one fifo. */
+  bytes_read = read_from_pipeline (transmit, FIFO_READ_LIMIT_BYTES);
+  read_from_pipeline (transmit, bytes_read + FIFO_READ_LIMIT_BYTES);
+
+  g_main_context_pop_thread_default (g_main_loop_get_context (fixture->loop));
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -252,6 +343,10 @@ main (int argc, char *argv[])
   g_test_add ("/gaeguli/fifo-transmit-add-remove-random",
       TestFixture, NULL, fixture_setup,
       test_gaeguli_fifo_transmit_add_remove_random, fixture_teardown);
+
+  g_test_add ("/gaeguli/fifo-transmit-reattach-stream",
+      TestFixture, NULL, fixture_setup,
+      test_gaeguli_fifo_transmit_reattach_stream, fixture_teardown);
 
   return g_test_run ();
 }

--- a/tests/test-fifo-transmit.c
+++ b/tests/test-fifo-transmit.c
@@ -221,6 +221,7 @@ test_gaeguli_fifo_transmit_add_remove_random (TestFixture * fixture,
   g_timeout_add (20, (GSourceFunc) add_remove_fifo_cb, &data);
   g_main_loop_run (fixture->loop);
 
+  gaeguli_pipeline_stop (data.pipeline);
   g_clear_object (&data.pipeline);
   for (i = 0; i != G_N_ELEMENTS (data.fifos); ++i) {
     g_clear_object (&data.fifos[i].transmit);

--- a/tests/test-fifo-transmit.c
+++ b/tests/test-fifo-transmit.c
@@ -208,6 +208,7 @@ test_gaeguli_fifo_transmit_add_remove_random (TestFixture * fixture,
     gconstpointer unused)
 {
   AddRemoveTestData data = { 0 };
+  guint idle_source;
   gint i;
 
   g_mutex_init (&data.lock);
@@ -218,8 +219,9 @@ test_gaeguli_fifo_transmit_add_remove_random (TestFixture * fixture,
   g_signal_connect (data.pipeline, "stream-stopped",
       (GCallback) stream_stopped_cb, &data);
 
-  g_timeout_add (20, (GSourceFunc) add_remove_fifo_cb, &data);
+  idle_source = g_timeout_add (20, (GSourceFunc) add_remove_fifo_cb, &data);
   g_main_loop_run (fixture->loop);
+  g_source_remove (idle_source);
 
   gaeguli_pipeline_stop (data.pipeline);
   g_clear_object (&data.pipeline);

--- a/tests/test-pipeline.c
+++ b/tests/test-pipeline.c
@@ -66,7 +66,10 @@ test_gaeguli_pipeline_instance (TestFixture * fixture, gconstpointer unused)
       fixture);
   g_signal_connect (pipeline, "stream-stopped", G_CALLBACK (_stream_stopped_cb),
       fixture);
-  target_id = gaeguli_pipeline_add_fifo_target (pipeline, "/dev/null", &error);
+
+  target_id = gaeguli_pipeline_add_fifo_target_full (pipeline,
+      GAEGULI_VIDEO_CODEC_H264, GAEGULI_VIDEO_RESOLUTION_640x480,
+      "/dev/null", &error);
 
   g_assert_cmpuint (target_id, !=, 0);
   fixture->target_id = target_id;

--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -30,6 +30,7 @@ main (int argc, char *argv[])
 {
   gboolean help;
   const gchar *fifo = NULL;
+  int result;
 
   g_autoptr (GError) error = NULL;
   g_autoptr (GApplication) app =
@@ -64,5 +65,9 @@ main (int argc, char *argv[])
   g_signal_connect (app, "activate", G_CALLBACK (activate), pipeline);
   g_object_set_data_full (G_OBJECT (app), "fifo", g_strdup (fifo), g_free);
 
-  return g_application_run (app, argc, argv);
+  result = g_application_run (app, argc, argv);
+
+  gaeguli_pipeline_stop (pipeline);
+
+  return result;
 }

--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -16,12 +16,12 @@ activate (GApplication * app, gpointer user_data)
 {
   g_autoptr (GError) error = NULL;
   const gchar *fifo = NULL;
-  guint target_id;
+
 
   GaeguliPipeline *pipeline = user_data;
 
   fifo = g_object_get_data (G_OBJECT (app), "fifo");
-  target_id = gaeguli_pipeline_add_fifo_target (pipeline, fifo, &error);
+  gaeguli_pipeline_add_fifo_target (pipeline, fifo, &error);
   g_application_hold (app);
 }
 


### PR DESCRIPTION
Checks that a fifo is kept open after one pipeline finished streaming and is ready to receive data from another one.