### PR TITLE
pipeline: fix unintialized value

### DIFF
--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -28,7 +28,7 @@ activate (GApplication * app, gpointer user_data)
 int
 main (int argc, char *argv[])
 {
-  gboolean help;
+  gboolean help = FALSE;
   const gchar *fifo = NULL;
   int result;
 


### PR DESCRIPTION
g_option_context_parse() won't initialize the variable if --help wasn't at the command line.