### PR TITLE
Fifo transmit tests

### DIFF
--- a/gaeguli/fifo-transmit.c
+++ b/gaeguli/fifo-transmit.c
@@ -565,7 +565,6 @@ _send_to (GaeguliFifoTransmit * self, gconstpointer buf, gsize len)
   g_hash_table_iter_init (&iter, self->sockets);
 
   while (g_hash_table_iter_next (&iter, &key, &value)) {
-    /* TODO: support to be listener */
     _send_to_listener (self, (SRTInfo *) value, buf, len);
   }
 }


### PR DESCRIPTION
* Try creating and removing listeners at random. Check that fifo transmit doesn't crash.
* Check that the fifo is kept open for the whole lifetime of GaeguliFifoTransmit and can get reused by different receivers.