### PR TITLE
debian: set DEB_BUILD_OPTIONS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+DEB_BUILD_OPTIONS=nocheck
+
 %:
 	dh $@
 


### PR DESCRIPTION
PPA seems not to support to set environment variables.