### PR TITLE
fifo-transmit: allow setting stream username

### DIFF
--- a/gaeguli/fifo-transmit.h
+++ b/gaeguli/fifo-transmit.h
@@ -54,6 +54,14 @@ guint                   gaeguli_fifo_transmit_start    (GaeguliFifoTransmit    *
                                                         GaeguliSRTMode          mode,
                                                         GError                **error);
 
+guint                   gaeguli_fifo_transmit_start_full
+                                                       (GaeguliFifoTransmit    *self,
+                                                        const gchar            *host,
+                                                        guint                   port,
+                                                        GaeguliSRTMode          mode,
+                                                        const gchar            *username,
+                                                        GError                **error);
+
 gboolean                gaeguli_fifo_transmit_stop     (GaeguliFifoTransmit    *self,
                                                         guint                   transmit_id,
                                                         GError                **error); 


### PR DESCRIPTION
The value is sent as 'u' standard key of SRT Stream ID.