### PR TITLE
pipeline: allow re-setting video caps

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -26,7 +26,7 @@
    \"mode\": %" G_GINT32_FORMAT " \
 }"
 
-#define GAEGULI_PIPELINE_VSRC_STR       "%s ! video/x-raw,width=%d,height=%d ! clockoverlay name=overlay ! tee name=tee allow-not-linked=1 "
+#define GAEGULI_PIPELINE_VSRC_STR       "%s ! capsfilter name=caps ! clockoverlay name=overlay ! tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc tune=zerolatency ! \

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -588,8 +588,6 @@ _link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
 
     g_mutex_lock (&link_target->self->lock);
 
-    g_hash_table_remove (link_target->self->targets,
-        GINT_TO_POINTER (link_target->target_id));
     if (g_hash_table_size (self->targets) == 0 &&
         self->stop_pipeline_event_id == 0) {
       self->stop_pipeline_event_id = g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
@@ -718,6 +716,8 @@ gaeguli_pipeline_remove_target (GaeguliPipeline * self, guint target_id,
     g_debug ("no target pipeline mapped with [%x]", target_id);
     goto out;
   }
+
+  g_hash_table_remove (self->targets, GINT_TO_POINTER (target_id));
 
   ghost_sinkpad = gst_element_get_static_pad (target_pipeline, "ghost_sink");
   ghost_srcpad = gst_pad_get_peer (ghost_sinkpad);


### PR DESCRIPTION
The very first FIFO target added to the pipeline decides what the output
video resolution will be, any subsequent FIFOs only inherit that value
and their own resolution setting is ignored.

When all FIFOs are removed (self->target becomes empty), give the FIFO
that gets added next a chance to re-set the stream resolution to some
new value.

This also shows the API of GaeguliPipeline isn't well defined. Either
the resolution should be a property of the whole GaeguliPipeline, not
individual targets, or each target pipeline should include a videoscale
element that will produce stream in that target's requested resolution.

