### PR TITLE
debian: make libgaeguli1 depend on GStreamer plugins good and ugly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Vcs-Git: https://github.com/hwangsaeul/gaeguli.git
 Package: libgaeguli1
 Architecture: any
 Depends:
- gstreamer1.0-plugins-bad,
+ gstreamer1.0-plugins-good, gstreamer1.0-plugins-bad, gstreamer1.0-plugins-ugly,
  ${shlibs:Depends}, ${misc:Depends}
 Description: Ultra-low latency SRT streamer
  Gæguli is an SRT streamer designed for edge devices that require


### PR DESCRIPTION
... on order to have v4l2src and x264enc available.