### PR TITLE
pipeline: add support for cameras with image/jpeg when using general enconding

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -26,7 +26,13 @@
    \"mode\": %" G_GINT32_FORMAT " \
 }"
 
-#define GAEGULI_PIPELINE_VSRC_STR       "%s ! capsfilter name=caps ! clockoverlay name=overlay ! tee name=tee allow-not-linked=1 "
+#define GAEGULI_PIPELINE_GENERAL_VSRC_STR       "\
+        %s ! capsfilter name=caps ! decodebin ! clockoverlay name=overlay ! \
+        tee name=tee allow-not-linked=1 "
+
+#define GAEGULI_PIPELINE_NVIDIA_TX1_VSRC_STR    "\
+        %s ! capsfilter name=caps ! clockoverlay name=overlay ! \
+        tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc tune=zerolatency bitrate=%d ! \

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -70,6 +70,12 @@ typedef struct _LinkTarget
   GstElement *target;
 } LinkTarget;
 
+static const gchar *const supported_formats[] = {
+  "video/x-raw",
+  "image/jpeg",
+  NULL
+};
+
 static LinkTarget *
 link_target_new (GaeguliPipeline * self, GstElement * src, guint target_id,
     GstElement * target, gboolean link)
@@ -528,7 +534,7 @@ static void
 _set_stream_caps (GaeguliPipeline * self, GaeguliVideoResolution resolution,
     guint framerate)
 {
-  gint width, height;
+  gint width, height, i;
   g_autoptr (GstElement) capsfilter = NULL;
   g_autoptr (GstCaps) caps = NULL;
 
@@ -555,11 +561,17 @@ _set_stream_caps (GaeguliPipeline * self, GaeguliVideoResolution resolution,
       break;
   }
 
-  caps = gst_caps_new_simple ("video/x-raw", "width", G_TYPE_INT, width,
-      "height", G_TYPE_INT, height,
-      "framerate", GST_TYPE_FRACTION, framerate, 1, NULL);
-  capsfilter = gst_bin_get_by_name (GST_BIN (self->pipeline), "caps");
+  caps = gst_caps_new_empty ();
 
+  for (i = 0; supported_formats[i] != NULL; i++) {
+    gst_caps_append (caps,
+        gst_caps_new_simple (supported_formats[i],
+            "width", G_TYPE_INT, width,
+            "height", G_TYPE_INT, height,
+            "framerate", GST_TYPE_FRACTION, framerate, 1, NULL));
+  }
+
+  capsfilter = gst_bin_get_by_name (GST_BIN (self->pipeline), "caps");
   g_object_set (capsfilter, "caps", caps, NULL);
 }
 

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -449,6 +449,31 @@ _get_source_description (GaeguliPipeline * self)
   return g_string_free (result, FALSE);
 }
 
+struct source_video_params
+{
+  const gchar *pipeline_str;
+  GaeguliEncodingMethod encoding_method;
+};
+
+static struct source_video_params vsrc_params[] = {
+  {GAEGULI_PIPELINE_GENERAL_VSRC_STR, GAEGULI_ENCODING_METHOD_GENERAL},
+  {GAEGULI_PIPELINE_NVIDIA_TX1_VSRC_STR, GAEGULI_ENCODING_METHOD_NVIDIA_TX1},
+  {NULL, 0},
+};
+
+static const gchar *
+_get_vsrc_pipeline_string (GaeguliEncodingMethod encoding_method)
+{
+  struct source_video_params *params = vsrc_params;
+
+  for (; params->pipeline_str != NULL; params++) {
+    if (params->encoding_method == encoding_method)
+      return params->pipeline_str;
+  }
+
+  return NULL;
+}
+
 static gboolean
 _build_vsrc_pipeline (GaeguliPipeline * self, GError ** error)
 {
@@ -461,7 +486,9 @@ _build_vsrc_pipeline (GaeguliPipeline * self, GError ** error)
   src_description = _get_source_description (self);
 
   /* FIXME: what if zero-copy */
-  vsrc_str = g_strdup_printf (GAEGULI_PIPELINE_VSRC_STR, src_description);
+  vsrc_str =
+      g_strdup_printf (_get_vsrc_pipeline_string (self->encoding_method),
+      src_description);
 
   g_debug ("trying to create video source pipeline (%s)", vsrc_str);
   self->vsrc = gst_parse_launch (vsrc_str, &internal_err);


### PR DESCRIPTION
Based on @justinjoy suggestion this implementation only adds image/jpeg support when encoding is set to general, so this change shouldn't affect nvidia configuration.