### PR TITLE
tools: don't set application ID

### DIFF
--- a/tools/fifo-transmit.c
+++ b/tools/fifo-transmit.c
@@ -76,8 +76,7 @@ main (int argc, char *argv[])
 {
   FifoTransmitOptions options;
   g_autoptr (GError) error = NULL;
-  g_autoptr (GApplication) app =
-      g_application_new ("org.hwangsaeul.Gaeguli1.FifoTransmitApp", 0);
+  g_autoptr (GApplication) app = g_application_new (NULL, 0);
 
   g_autoptr (GOptionGroup) group = NULL;
   g_autoptr (GOptionContext) context = NULL;

--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -62,8 +62,7 @@ main (int argc, char *argv[])
   int result;
 
   g_autoptr (GError) error = NULL;
-  g_autoptr (GApplication) app =
-      g_application_new ("org.hwangsaeul.Gaeguli1.PipelineApp", 0);
+  g_autoptr (GApplication) app = g_application_new (NULL, 0);
 
   g_autoptr (GOptionContext) context = NULL;
   GOptionEntry entries[] = {


### PR DESCRIPTION
It prevents concurrent launches of 'fifo-transit-1.0' and 'pipeline-1.0'
in the same session and those tools don't use D-Bus anyway.