### PR TITLE
pipeline: stop GST pipeline before cleaning GaeguliPipeline

### DIFF
--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -973,11 +973,13 @@ out:
 void
 gaeguli_pipeline_stop (GaeguliPipeline * self)
 {
-  g_autoptr (GstElement) pipeline = NULL;
-
   g_return_if_fail (GAEGULI_IS_PIPELINE (self));
 
   g_debug ("clear internal pipeline");
+
+  if (self->pipeline) {
+    gst_element_set_state (self->pipeline, GST_STATE_NULL);
+  }
 
   g_mutex_lock (&self->lock);
 
@@ -988,13 +990,9 @@ gaeguli_pipeline_stop (GaeguliPipeline * self)
 
   g_clear_pointer (&self->vsrc, gst_object_unref);
   g_clear_pointer (&self->overlay, gst_object_unref);
-  pipeline = g_steal_pointer (&self->pipeline);
+  gst_clear_object (&self->pipeline);
 
   g_mutex_unlock (&self->lock);
-
-  if (pipeline) {
-    gst_element_set_state (pipeline, GST_STATE_NULL);
-  }
 }
 
 void


### PR DESCRIPTION
Avoids possible NULL dereference of link_target->self->vsrc in _link_probe_cb() when gaeguli_pipeline_remove_target() and
gaeguli_pipeline_stop() are called in quick succession.