### PR TITLE
Stream adaptor base

### DIFF
--- a/gaeguli/adaptors/nulladaptor.c
+++ b/gaeguli/adaptors/nulladaptor.c
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <adaptors/nulladaptor.h>
+#include <gst/gstelement.h>
+
+struct _GaeguliNullStreamAdaptor
+{
+  GaeguliStreamAdaptor parent;
+};
+
+/* *INDENT-OFF* */
+G_DEFINE_TYPE (GaeguliNullStreamAdaptor, gaeguli_null_stream_adaptor,
+    GAEGULI_TYPE_STREAM_ADAPTOR)
+/* *INDENT-ON* */
+
+GaeguliStreamAdaptor *
+gaeguli_null_stream_adaptor_new (GstElement * srtsink)
+{
+  g_return_val_if_fail (srtsink != NULL, NULL);
+
+  return g_object_new (GAEGULI_TYPE_NULL_STREAM_ADAPTOR, "srtsink", srtsink,
+      NULL);
+}
+
+static void
+gaeguli_null_stream_adaptor_init (GaeguliNullStreamAdaptor * self)
+{
+}
+
+static void
+gaeguli_null_stream_adaptor_class_init (GaeguliNullStreamAdaptorClass * klass)
+{
+}

--- a/gaeguli/adaptors/nulladaptor.h
+++ b/gaeguli/adaptors/nulladaptor.h
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef __GAEGULI_NULL_STREAM_ADAPTOR_H__
+#define __GAEGULI_NULL_STREAM_ADAPTOR_H__
+
+#include "gaeguli/gaeguli.h"
+
+#include <gst/gst.h>
+
+G_BEGIN_DECLS
+
+#define GAEGULI_TYPE_NULL_STREAM_ADAPTOR   (gaeguli_null_stream_adaptor_get_type ())
+G_DECLARE_FINAL_TYPE (GaeguliNullStreamAdaptor, gaeguli_null_stream_adaptor, GAEGULI,
+    NULL_STREAM_ADAPTOR, GaeguliStreamAdaptor)
+
+/**
+ * gaeguli_null_stream_adaptor_new:
+ * @srtsink: a #GstSrtSink element to collect data from
+ *
+ * Creates a null stream adaptor that doesn't perform any adaption.
+ *
+ * Returns: a #GaeguliStreamAdaptor instance
+ */
+GaeguliStreamAdaptor     *gaeguli_null_stream_adaptor_new
+                                                (GstElement            *srtsink);
+
+G_END_DECLS
+
+#endif // __GAEGULI_NULL_STREAM_ADAPTOR_H__

--- a/gaeguli/meson.build
+++ b/gaeguli/meson.build
@@ -13,6 +13,8 @@ source_h = [
 source_c = [
   'types.c',
   'pipeline.c',
+  'streamadaptor.c',
+  'adaptors/nulladaptor.c',
 ]
 
 install_headers(source_h, subdir: gaeguli_install_header_subdir)

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -57,6 +57,8 @@ struct _GaeguliPipeline
   gboolean show_overlay;
 
   guint stop_pipeline_event_id;
+
+  GType adaptor_type;
 };
 
 typedef struct _LinkTarget
@@ -136,6 +138,7 @@ typedef enum
   PROP_DEVICE,
   PROP_ENCODING_METHOD,
   PROP_CLOCK_OVERLAY,
+  PROP_STREAM_ADAPTOR,
 
   /*< private > */
   PROP_LAST
@@ -197,6 +200,9 @@ gaeguli_pipeline_get_property (GObject * object,
     case PROP_CLOCK_OVERLAY:
       g_value_set_boolean (value, self->show_overlay);
       break;
+    case PROP_STREAM_ADAPTOR:
+      g_value_set_gtype (value, self->adaptor_type);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -226,6 +232,9 @@ gaeguli_pipeline_set_property (GObject * object,
       if (self->overlay) {
         g_object_set (self->overlay, "silent", !self->show_overlay, NULL);
       }
+      break;
+    case PROP_STREAM_ADAPTOR:
+      self->adaptor_type = g_value_get_gtype (value);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -259,6 +268,11 @@ gaeguli_pipeline_class_init (GaeguliPipelineClass * klass)
       g_param_spec_boolean ("clock-overlay", "clock overlay",
       "Overlay the current time on the video stream", FALSE,
       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_STREAM_ADAPTOR] =
+      g_param_spec_gtype ("stream-adaptor", "stream adaptor",
+      "Type of network stream adoption the pipeline should perform",
+      GAEGULI_TYPE_STREAM_ADAPTOR, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, G_N_ELEMENTS (properties),
       properties);
@@ -295,6 +309,8 @@ gaeguli_pipeline_init (GaeguliPipeline * self)
   /* kv: hash(fifo-path), target_pipeline */
   self->targets = g_hash_table_new_full (g_direct_hash, g_direct_equal,
       NULL, (GDestroyNotify) gst_object_unref);
+
+  self->adaptor_type = GAEGULI_TYPE_NULL_STREAM_ADAPTOR;
 }
 
 GaeguliPipeline *

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -39,6 +39,14 @@ enum
   PROP_LAST
 };
 
+enum
+{
+  SIG_ENCODING_PARAMETERS,
+  LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0 };
+
 static void
 gaeguli_stream_adaptor_collect_stats (GaeguliStreamAdaptor * self)
 {
@@ -101,6 +109,21 @@ gaeguli_stream_adaptor_set_stats_interval (GaeguliStreamAdaptor * self,
     g_clear_handle_id (&priv->stats_timeout_id, g_source_remove);
     gaeguli_stream_adaptor_start_timer (self);
   }
+}
+
+void
+gaeguli_stream_adaptor_signal_encoding_parameters (GaeguliStreamAdaptor * self,
+    const gchar * param, ...)
+{
+  g_autoptr (GstStructure) s = NULL;
+  va_list varargs;
+
+  va_start (varargs, param);
+  s = gst_structure_new_valist ("application/x-gaeguli-encoding-parameters",
+      param, varargs);
+  va_end (varargs);
+
+  g_signal_emit (self, signals[SIG_ENCODING_PARAMETERS], 0, s);
 }
 
 static void
@@ -175,4 +198,9 @@ gaeguli_stream_adaptor_class_init (GaeguliStreamAdaptorClass * klass)
       g_param_spec_uint ("stats-interval", "Statistics collection interval",
           "Statistics collection interval in milliseconds", 1, G_MAXUINT, 10,
           G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+
+  signals[SIG_ENCODING_PARAMETERS] =
+      g_signal_new ("encoding-parameters", G_TYPE_FROM_CLASS (klass),
+      G_SIGNAL_RUN_LAST, 0, NULL,
+      NULL, NULL, G_TYPE_NONE, 1, GST_TYPE_STRUCTURE);
 }

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -1,0 +1,86 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "streamadaptor.h"
+
+#include <gst/gstelement.h>
+
+typedef struct
+{
+  GstElement *srtsink;
+
+} GaeguliStreamAdaptorPrivate;
+
+/* *INDENT-OFF* */
+G_DEFINE_TYPE_WITH_PRIVATE (GaeguliStreamAdaptor, gaeguli_stream_adaptor,
+    G_TYPE_OBJECT)
+/* *INDENT-ON* */
+
+enum
+{
+  PROP_SRTSINK = 1,
+  PROP_LAST
+};
+
+static void
+gaeguli_stream_adaptor_init (GaeguliStreamAdaptor * self)
+{
+}
+
+static void
+gaeguli_stream_adaptor_set_property (GObject * object, guint property_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GaeguliStreamAdaptor *self = GAEGULI_STREAM_ADAPTOR (object);
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
+
+  switch (property_id) {
+    case PROP_SRTSINK:
+      priv->srtsink = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+  }
+}
+
+static void
+gaeguli_stream_adaptor_dispose (GObject * object)
+{
+  GaeguliStreamAdaptor *self = GAEGULI_STREAM_ADAPTOR (object);
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
+
+  gst_clear_object (&priv->srtsink);
+
+  G_OBJECT_CLASS (gaeguli_stream_adaptor_parent_class)->dispose (object);
+}
+
+static void
+gaeguli_stream_adaptor_class_init (GaeguliStreamAdaptorClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->set_property = gaeguli_stream_adaptor_set_property;
+  gobject_class->dispose = gaeguli_stream_adaptor_dispose;
+
+  g_object_class_install_property (gobject_class, PROP_SRTSINK,
+      g_param_spec_object ("srtsink", "SRT sink",
+          "SRT sink", GST_TYPE_ELEMENT,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+}

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -20,10 +20,12 @@
 
 #include <gst/gstelement.h>
 
+#define ADAPTOR_STATS_COLLECTION_INTERVAL_SECONDS 5
+
 typedef struct
 {
   GstElement *srtsink;
-
+  guint stats_timeout_id;
 } GaeguliStreamAdaptorPrivate;
 
 /* *INDENT-OFF* */
@@ -38,6 +40,47 @@ enum
 };
 
 static void
+gaeguli_stream_adaptor_collect_stats (GaeguliStreamAdaptor * self)
+{
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
+  GaeguliStreamAdaptorClass *klass = GAEGULI_STREAM_ADAPTOR_GET_CLASS (self);
+
+  g_autoptr (GstStructure) s = NULL;
+
+  g_object_get (priv->srtsink, "stats", &s, NULL);
+
+  if (gst_structure_n_fields (s) != 0) {
+    klass->on_stats (self, s);
+  }
+}
+
+gboolean
+_stats_collection_timeout (gpointer user_data)
+{
+  gaeguli_stream_adaptor_collect_stats (user_data);
+
+  return G_SOURCE_CONTINUE;
+}
+
+static void
+gaeguli_stream_adaptor_set_srtsink (GaeguliStreamAdaptor * self,
+    GstElement * srtsink)
+{
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
+  GaeguliStreamAdaptorClass *klass = GAEGULI_STREAM_ADAPTOR_GET_CLASS (self);
+
+  priv->srtsink = gst_object_ref (srtsink);
+
+  if (klass->on_stats) {
+    priv->stats_timeout_id =
+        g_timeout_add_seconds (ADAPTOR_STATS_COLLECTION_INTERVAL_SECONDS,
+        _stats_collection_timeout, self);
+  }
+}
+
+static void
 gaeguli_stream_adaptor_init (GaeguliStreamAdaptor * self)
 {
 }
@@ -47,12 +90,10 @@ gaeguli_stream_adaptor_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
   GaeguliStreamAdaptor *self = GAEGULI_STREAM_ADAPTOR (object);
-  GaeguliStreamAdaptorPrivate *priv =
-      gaeguli_stream_adaptor_get_instance_private (self);
 
   switch (property_id) {
     case PROP_SRTSINK:
-      priv->srtsink = g_value_dup_object (value);
+      gaeguli_stream_adaptor_set_srtsink (self, g_value_get_object (value));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -67,6 +108,7 @@ gaeguli_stream_adaptor_dispose (GObject * object)
       gaeguli_stream_adaptor_get_instance_private (self);
 
   gst_clear_object (&priv->srtsink);
+  g_clear_handle_id (&priv->stats_timeout_id, g_source_remove);
 
   G_OBJECT_CLASS (gaeguli_stream_adaptor_parent_class)->dispose (object);
 }

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -23,7 +23,7 @@
 #error "Only <gaeguli/gaeguli.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <gst/gst.h>
 
 G_BEGIN_DECLS
 
@@ -34,6 +34,9 @@ G_DECLARE_DERIVABLE_TYPE (GaeguliStreamAdaptor, gaeguli_stream_adaptor, GAEGULI,
 struct _GaeguliStreamAdaptorClass
 {
   GObjectClass parent_class;
+
+  void      (* on_stats)                 (GaeguliStreamAdaptor * self,
+                                          GstStructure * stats);
 };
 
 G_END_DECLS

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -27,6 +27,11 @@
 
 G_BEGIN_DECLS
 
+/* Bitrate in bits/second */
+#define GAEGULI_ENCODING_PARAMETER_BITRATE "bitrate"
+/* Constant quantizer to apply */
+#define GAEGULI_ENCODING_PARAMETER_QUANTIZER "quantizer"
+
 #define GAEGULI_TYPE_STREAM_ADAPTOR   (gaeguli_stream_adaptor_get_type ())
 G_DECLARE_DERIVABLE_TYPE (GaeguliStreamAdaptor, gaeguli_stream_adaptor, GAEGULI,
     STREAM_ADAPTOR, GObject)
@@ -38,6 +43,11 @@ struct _GaeguliStreamAdaptorClass
   void      (* on_stats)                 (GaeguliStreamAdaptor * self,
                                           GstStructure * stats);
 };
+
+void                    gaeguli_stream_adaptor_signal_encoding_parameters
+                                                (GaeguliStreamAdaptor       *self,
+                                                 const gchar                *param,
+                                                 ...) G_GNUC_NULL_TERMINATED;
 
 G_END_DECLS
 

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef __GAEGULI_STREAM_ADAPTOR_H__
+#define __GAEGULI_STREAM_ADAPTOR_H__
+
+#if !defined(__GAEGULI_INSIDE__) && !defined(GAEGULI_COMPILATION)
+#error "Only <gaeguli/gaeguli.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define GAEGULI_TYPE_STREAM_ADAPTOR   (gaeguli_stream_adaptor_get_type ())
+G_DECLARE_DERIVABLE_TYPE (GaeguliStreamAdaptor, gaeguli_stream_adaptor, GAEGULI,
+    STREAM_ADAPTOR, GObject)
+
+struct _GaeguliStreamAdaptorClass
+{
+  GObjectClass parent_class;
+};
+
+G_END_DECLS
+
+#endif // __GAEGULI_STREAM_ADAPTOR_H__

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gaeguli', 'c',
   version: '0.11.0',
   license: 'Apache-2.0',
-  meson_version: '>= 0.40',
+  meson_version: '>= 0.46',
   default_options: [ 'warning_level=1',
                      'buildtype=debugoptimized',
                      'c_std=gnu89',

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -1,0 +1,10 @@
+sources = [
+  'receiver.c',
+]
+
+libhwangsae_test_common = library(
+  'gaeguli-test-common',
+  sources,
+  dependencies: [ libgaeguli_dep ],
+  install: false
+)

--- a/tests/common/receiver.c
+++ b/tests/common/receiver.c
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "receiver.h"
+
+GstElement *
+gaeguli_tests_create_receiver (GaeguliSRTMode mode, guint port,
+    GCallback handoff_callback, gpointer data)
+{
+  g_autoptr (GError) error = NULL;
+  g_autoptr (GstElement) receiver = NULL;
+  g_autoptr (GstElement) sink = NULL;
+  g_autofree gchar *pipeline_str = NULL;
+  gchar *mode_str = mode == GAEGULI_SRT_MODE_CALLER ? "caller" : "listener";
+
+  pipeline_str = g_strdup_printf ("srtsrc uri=srt://127.0.0.1:%d?mode=%s ! "
+      "fakesink name=sink signal-handoffs=1", port, mode_str);
+
+  receiver = gst_parse_launch (pipeline_str, &error);
+  g_assert_no_error (error);
+
+  if (handoff_callback) {
+    sink = gst_bin_get_by_name (GST_BIN (receiver), "sink");
+    g_signal_connect (sink, "handoff", handoff_callback, data);
+  }
+
+  gst_element_set_state (receiver, GST_STATE_PLAYING);
+
+  return g_steal_pointer (&receiver);
+}

--- a/tests/common/receiver.h
+++ b/tests/common/receiver.h
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "gaeguli/gaeguli.h"
+
+GstElement       *gaeguli_tests_create_receiver (GaeguliSRTMode mode,
+                                                 guint port,
+                                                 GCallback handoff_callback,
+                                                 gpointer data);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,5 @@
+subdir('common')
+
 tests = [
   'test-pipeline',
   'test-adaptor',
@@ -9,8 +11,8 @@ foreach t: tests
   exe = executable(
     t, '@0@.c'.format(t),
     c_args: '-DG_LOG_DOMAIN="gaeguli-tests"',
-    include_directories: gaeguli_incs,
     dependencies: [ libgaeguli_dep ],
+    link_with: libhwangsae_test_common,
     install: false,
   )
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 tests = [
   'test-pipeline',
+  'test-adaptor',
 ]
 
 foreach t: tests

--- a/tests/test-adaptor.c
+++ b/tests/test-adaptor.c
@@ -55,8 +55,9 @@ gaeguli_test_adaptor_on_stats (GaeguliStreamAdaptor * self,
 {
   GaeguliTestAdaptor *test_adaptor = GAEGULI_TEST_ADAPTOR (self);
   guint64 now = g_get_monotonic_time ();
+  g_autofree gchar *stats_str = gst_structure_to_string (stats);
 
-  g_debug ("Stats callback invoked");
+  g_debug ("Stats callback invoked with stats structure: %s", stats_str);
 
   g_assert_nonnull (stats);
   g_assert_cmpstr (gst_structure_get_name (stats), ==,

--- a/tests/test-adaptor.c
+++ b/tests/test-adaptor.c
@@ -1,6 +1,9 @@
 /**
+ *  tests/test-pipeline
+ *
  *  Copyright 2019 SK Telecom Co., Ltd.
  *    Author: Jeongseok Kim <jeongseok.kim@sk.com>
+ *            Jakub Adam <jakub.adam@collabora.com>
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,14 +19,25 @@
  *
  */
 
-#ifndef __GAEGULI_H__
-#define __GAEGULI_H__
+#include <adaptors/nulladaptor.h>
 
-#define __GAEGULI_INSIDE__
+static void
+test_gaeguli_adaptor_instance ()
+{
+  g_autoptr (GstElement) srtsink = gst_element_factory_make ("srtsink", NULL);
+  g_autoptr (GaeguliStreamAdaptor) adaptor = NULL;
 
-#include <gaeguli/types.h>
-#include <gaeguli/enumtypes.h>
-#include <gaeguli/pipeline.h>
-#include <gaeguli/streamadaptor.h>
+  adaptor = gaeguli_null_stream_adaptor_new (srtsink);
+  g_assert_nonnull (adaptor);
+}
 
-#endif // __GAEGULI_H__
+int
+main (int argc, char *argv[])
+{
+  gst_init (&argc, &argv);
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/gaeguli/adaptor-instance", test_gaeguli_adaptor_instance);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
Implements `GaeguliStreamAdaptor` as the base class for writing decision-making modules and adds basic tests.

Merge request covers the following acceptance criteria:

* **The API notifies the module when a new srtsink pair becomes available** (in this implementation, the 'notification' is the fact that an instance of `GaeguliStreamAdaptor` subclass gets created, which allows for adding some initialization code into `init`, `constructed`, etc. GObject methods)
* **The API notifies the module when srtsink connection is closed** (`GaeguliStreamAdaptor` instance gets destroyed on target removal, so cleanup code can be put into GObject finalize methods)
* **The API allows the module to periodically collect statistics from active srtsink elements**
* **The API doesn’t require decision modules be rebuilt when a new type of value is added into the set of measured statistics** (It uses GstStructure created by srtsink)