### PR TITLE
adaptor: pass initial encoder settings to adaptor construction

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -32,11 +32,11 @@
         tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
-        queue name=enc_first ! videoconvert ! x264enc tune=zerolatency bitrate=%d ! \
+        queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency bitrate=%d ! \
         h264parse ! queue "
 
 #define GAEGULI_PIPELINE_GENERAL_H265ENC_STR    "\
-        queue name=enc_first ! videoconvert ! x265enc tune=zerolatency bitrate=%d ! \
+        queue name=enc_first ! videoconvert ! x265enc name=enc tune=zerolatency bitrate=%d ! \
         h265parse ! queue "
 
 /* nvidia tx1 pipeline (for v4l2src) */
@@ -46,11 +46,11 @@
 
 #define GAEGULI_PIPELINE_NVIDIA_TX1_H264ENC_STR    "\
         queue name=enc_first ! nvvidconv ! video/x-raw(memory:NVMM),format=I420 ! \
-        omxh264enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d ! queue "
+        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d ! queue "
 
 #define GAEGULI_PIPELINE_NVIDIA_TX1_H265ENC_STR    "\
         queue name=enc_first ! nvvidconv ! video/x-raw(memory:NVMM),format=I420 ! \
-        omxh264enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d ! queue "
+        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d ! queue "
 
 #define GAEGULI_PIPELINE_MUXSINK_STR    "\
         mpegtsmux name=muxsink_first ! tsparse set-timestamps=1 smoothing-latency=1000 ! \

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -445,6 +445,13 @@ _bus_sync_srtsink_error_handler (GstBus * bus, GstMessage * message,
   return GST_BUS_PASS;
 }
 
+static GstStructure *
+_get_encoding_parameters (GstElement * encoder)
+{
+  // TODO
+  return gst_structure_new_empty ("application/x-gaeguli-encoding-parameters");
+}
+
 static GaeguliTarget *
 _build_target (GaeguliEncodingMethod encoding_method, GaeguliVideoCodec codec,
     guint bitrate, const gchar * srt_uri, const gchar * username,
@@ -453,6 +460,7 @@ _build_target (GaeguliEncodingMethod encoding_method, GaeguliVideoCodec codec,
   g_autoptr (GaeguliTarget) target = NULL;
   g_autoptr (GstElement) srtsink = NULL;
   g_autoptr (GstElement) enc_first = NULL;
+  g_autoptr (GstElement) encoder = NULL;
   g_autoptr (GstBus) bus = NULL;
   g_autoptr (GstPad) enc_sinkpad = NULL;
   GstPad *ghost_pad = NULL;
@@ -497,7 +505,10 @@ _build_target (GaeguliEncodingMethod encoding_method, GaeguliVideoCodec codec,
   gst_bus_set_sync_handler (bus, _bus_sync_srtsink_error_handler, &internal_err,
       NULL);
 
-  target->adaptor = g_object_new (adaptor_type, "srtsink", srtsink, NULL);
+  encoder = gst_bin_get_by_name (GST_BIN (target->pipeline), "enc");
+
+  target->adaptor = g_object_new (adaptor_type, "srtsink", srtsink,
+      "initial-encoding-parameters", _get_encoding_parameters (encoder), NULL);
 
   /* Setting READY state on srtsink check that we can bind to address and port
    * specified in srt_uri. On failure, bus handler should set internal_err. */

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -23,6 +23,7 @@
 typedef struct
 {
   GstElement *srtsink;
+  GstStructure *initial_encoding_parameters;
   guint stats_interval;
   guint stats_timeout_id;
 } GaeguliStreamAdaptorPrivate;
@@ -35,6 +36,7 @@ G_DEFINE_TYPE_WITH_PRIVATE (GaeguliStreamAdaptor, gaeguli_stream_adaptor,
 enum
 {
   PROP_SRTSINK = 1,
+  PROP_INITIAL_ENCODING_PARAMETERS,
   PROP_STATS_INTERVAL,
   PROP_LAST
 };
@@ -136,10 +138,15 @@ gaeguli_stream_adaptor_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
   GaeguliStreamAdaptor *self = GAEGULI_STREAM_ADAPTOR (object);
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
 
   switch (property_id) {
     case PROP_SRTSINK:
       gaeguli_stream_adaptor_set_srtsink (self, g_value_get_object (value));
+      break;
+    case PROP_INITIAL_ENCODING_PARAMETERS:
+      priv->initial_encoding_parameters = g_value_get_boxed (value);
       break;
     case PROP_STATS_INTERVAL:
       gaeguli_stream_adaptor_set_stats_interval (self,
@@ -159,6 +166,9 @@ gaeguli_stream_adaptor_get_property (GObject * object, guint property_id,
       gaeguli_stream_adaptor_get_instance_private (self);
 
   switch (property_id) {
+    case PROP_INITIAL_ENCODING_PARAMETERS:
+      g_value_set_boxed (value, priv->initial_encoding_parameters);
+      break;
     case PROP_STATS_INTERVAL:
       g_value_set_uint (value, priv->stats_interval);
       break;
@@ -193,6 +203,13 @@ gaeguli_stream_adaptor_class_init (GaeguliStreamAdaptorClass * klass)
       g_param_spec_object ("srtsink", "SRT sink",
           "SRT sink", GST_TYPE_ELEMENT,
           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class,
+      PROP_INITIAL_ENCODING_PARAMETERS,
+      g_param_spec_boxed ("initial-encoding-parameters",
+          "Initial encoding parameters", "Initial encoding parameters",
+          GST_TYPE_STRUCTURE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_STATS_INTERVAL,
       g_param_spec_uint ("stats-interval", "Statistics collection interval",


### PR DESCRIPTION
Those settings set the baseline for any stream adaptation.