### PR TITLE
pipeline: add "connection-error" signal

### DIFF
--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -77,6 +77,7 @@ typedef struct _LinkTarget
 
 typedef struct _GaeguliTarget
 {
+  guint id;
   GstElement *pipeline;
   GstElement *srtsink;
   GaeguliStreamAdaptor *adaptor;
@@ -889,6 +890,8 @@ gaeguli_pipeline_add_srt_target_full (GaeguliPipeline * self,
       internal_err = NULL;
       goto failed;
     }
+
+    target->id = target_id;
 
     gst_bin_add (GST_BIN (self->pipeline), target->pipeline);
 


### PR DESCRIPTION
The signal fires when srtsink can't establish connection with its peer.

Depends on https://github.com/hwangsaeul/gst-plugins-bad/pull/3; failing tests are to be expected until that is merged and deployed on CI machine.

