### PR TITLE
pipeline: fix state change from streaming thread

### DIFF
--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -1056,6 +1056,8 @@ gaeguli_pipeline_remove_target (GaeguliPipeline * self, guint target_id,
     gst_pad_remove_probe (target->tee_srcpad, target->pending_pad_probe);
     target->pending_pad_probe = 0;
   } else {
+    gst_element_set_state (target->srtsink, GST_STATE_NULL);
+
     gst_pad_add_probe (target->tee_srcpad, GST_PAD_PROBE_TYPE_BLOCK,
         _link_probe_cb, link_target_new (self, self->vsrc, target_id,
             target->pipeline, FALSE), (GDestroyNotify) link_target_unref);


### PR DESCRIPTION
Link probe may get called from the streaming thread of the target it's
attempting to remove, so let the state change to NULL  happen in the
main thread.

Avoids:

Bail out! GStreamer-FATAL-WARNING:
Trying to join task 0x55591381e710 from its thread would deadlock.
You cannot change the state of an element from its streaming
thread. Use g_idle_add() or post a GstMessage on the bus to
schedule the state change from the main thread.