### PR TITLE
meson: bump meson_version to 0.48.2 and remove legacy code

### DIFF
--- a/gaeguli/meson.build
+++ b/gaeguli/meson.build
@@ -49,43 +49,14 @@ libgaeguli = library(
   install: true
 )
 
-if meson.version().version_compare('>= 0.48.2')
-
-  pkg.generate(libgaeguli,
-    libraries : [ gst_dep, libsrt_dep ],
-    name : meson.project_name(),
-    description : 'A SRT Streaming library',
-    filebase : gaeguli_api_name,
-    subdirs: gaeguli_api_name,
-    variables: 'exec_prefix=${prefix}'
-  )
-
-else
-
-  pkg.generate(
-    libraries : libgaeguli,
-    version : meson.project_version(),
-    name : meson.project_name(),
-    description : 'A SRT Streaming library',
-    filebase : gaeguli_api_name,
-    requires : [
-      'gstreamer-1.0',
-      'gstreamer-base-1.0',
-      'gstreamer-net-1.0',
-      'srt'
-    ],
-    requires_private : [
-      'glib-2.0 ' + glib_req_version,
-      'gobject-2.0 ' + glib_req_version,
-      'gio-2.0 ' + glib_req_version,
-      'gio-unix-2.0 ' + glib_req_version,
-    ],
-    subdirs: gaeguli_api_name,
-    variables: 'exec_prefix=${prefix}'
-  )
-
-endif
-
+pkg.generate(libgaeguli,
+  libraries : [ gst_dep, libsrt_dep ],
+  name : meson.project_name(),
+  description : 'A SRT Streaming library',
+  filebase : gaeguli_api_name,
+  subdirs: gaeguli_api_name,
+  variables: 'exec_prefix=${prefix}'
+)
 
 libgaeguli_dep = declare_dependency(link_with: libgaeguli,
   include_directories: [ gaeguli_incs ],

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gaeguli', 'c',
   version: '1.99.0',
   license: 'Apache-2.0',
-  meson_version: '>= 0.46',
+  meson_version: '>= 0.48.2',
   default_options: [ 'warning_level=1',
                      'buildtype=debugoptimized',
                      'c_std=gnu89',
@@ -99,8 +99,6 @@ subdir('tests')
 subdir('tools')
 subdir('doc')
 
-if meson.version().version_compare('>= 0.46.0')
-  python3 = import('python').find_installation()
-  run_command(python3, '-c',
-    'import shutil; shutil.copy("hooks/pre-commit.hook", ".git/hooks/pre-commit")')
-endif
+python3 = import('python').find_installation()
+run_command(python3, '-c',
+  'import shutil; shutil.copy("hooks/pre-commit.hook", ".git/hooks/pre-commit")')


### PR DESCRIPTION
Ubuntu 20.04 ships with meson 0.53.2 so we may safely assume all meson
features we need are supported.