### PR TITLE
Implement example stream adaptor

### DIFF
--- a/gaeguli/adaptors/bandwidthadaptor.c
+++ b/gaeguli/adaptors/bandwidthadaptor.c
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <adaptors/bandwidthadaptor.h>
+
+struct _GaeguliBandwidthStreamAdaptor
+{
+  GaeguliStreamAdaptor parent;
+};
+
+/* *INDENT-OFF* */
+G_DEFINE_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_adaptor,
+    GAEGULI_TYPE_STREAM_ADAPTOR)
+/* *INDENT-ON* */
+
+GaeguliStreamAdaptor *
+gaeguli_bandwidth_stream_adaptor_new (GstElement * srtsink)
+{
+  g_return_val_if_fail (srtsink != NULL, NULL);
+
+  return g_object_new (GAEGULI_TYPE_BANDWIDTH_STREAM_ADAPTOR,
+      "srtsink", srtsink, NULL);
+}
+
+static void
+gaeguli_bandwidth_stream_adaptor_init (GaeguliBandwidthStreamAdaptor * self)
+{
+}
+
+static void
+gaeguli_bandwidth_stream_adaptor_class_init (GaeguliBandwidthStreamAdaptorClass
+    * klass)
+{
+}

--- a/gaeguli/adaptors/bandwidthadaptor.h
+++ b/gaeguli/adaptors/bandwidthadaptor.h
@@ -30,6 +30,7 @@ G_DECLARE_FINAL_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_ad
 /**
  * gaeguli_bandwidth_stream_adaptor_new:
  * @srtsink: a #GstSrtSink element to collect data from
+ * @initial_encoding_params: initial encoding parameters
  *
  * Creates a stream adaptor that adjusts stream bitrate to the measured
  * bandwidth of the network connection.
@@ -37,7 +38,8 @@ G_DECLARE_FINAL_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_ad
  * Returns: a #GaeguliStreamAdaptor instance
  */
 GaeguliStreamAdaptor     *gaeguli_bandwidth_stream_adaptor_new
-                                                (GstElement            *srtsink);
+                                                (GstElement            *srtsink,
+                                                 GstStructure          *initial_encoding_params);
 
 G_END_DECLS
 

--- a/gaeguli/adaptors/bandwidthadaptor.h
+++ b/gaeguli/adaptors/bandwidthadaptor.h
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef __GAEGULI_BANDWIDTH_STREAM_ADAPTOR_H__
+#define __GAEGULI_BANDWIDTH_STREAM_ADAPTOR_H__
+
+#include "gaeguli/gaeguli.h"
+
+G_BEGIN_DECLS
+
+#define GAEGULI_TYPE_BANDWIDTH_STREAM_ADAPTOR   (gaeguli_bandwidth_stream_adaptor_get_type ())
+G_DECLARE_FINAL_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_adaptor, GAEGULI,
+    BANDWIDTH_STREAM_ADAPTOR, GaeguliStreamAdaptor)
+
+/**
+ * gaeguli_bandwidth_stream_adaptor_new:
+ * @srtsink: a #GstSrtSink element to collect data from
+ *
+ * Creates a stream adaptor that adjusts stream bitrate to the measured
+ * bandwidth of the network connection.
+ *
+ * Returns: a #GaeguliStreamAdaptor instance
+ */
+GaeguliStreamAdaptor     *gaeguli_bandwidth_stream_adaptor_new
+                                                (GstElement            *srtsink);
+
+G_END_DECLS
+
+#endif // __GAEGULI_BANDWIDTH_STREAM_ADAPTOR_H__

--- a/gaeguli/meson.build
+++ b/gaeguli/meson.build
@@ -16,6 +16,7 @@ source_c = [
   'pipeline.c',
   'streamadaptor.c',
   'adaptors/nulladaptor.c',
+  'adaptors/bandwidthadaptor.c',
 ]
 
 install_headers(source_h, subdir: gaeguli_install_header_subdir)


### PR DESCRIPTION
Makes video bitrate follow network bandwidth if it changes by at least 10%. Doesn't raise the bitrate over the encoder's initial setting.