### PR TITLE
streamadaptor: make get_stats public

### DIFF
--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -49,16 +49,24 @@ enum
 
 static guint signals[LAST_SIGNAL] = { 0 };
 
-static void
-gaeguli_stream_adaptor_collect_stats (GaeguliStreamAdaptor * self)
+GstStructure *
+gaeguli_stream_adaptor_get_stats (GaeguliStreamAdaptor * self)
 {
   GaeguliStreamAdaptorPrivate *priv =
       gaeguli_stream_adaptor_get_instance_private (self);
-  GaeguliStreamAdaptorClass *klass = GAEGULI_STREAM_ADAPTOR_GET_CLASS (self);
 
   g_autoptr (GstStructure) s = NULL;
 
   g_object_get (priv->srtsink, "stats", &s, NULL);
+
+  return g_steal_pointer (&s);
+}
+
+static void
+gaeguli_stream_adaptor_collect_stats (GaeguliStreamAdaptor * self)
+{
+  GaeguliStreamAdaptorClass *klass = GAEGULI_STREAM_ADAPTOR_GET_CLASS (self);
+  g_autoptr (GstStructure) s = gaeguli_stream_adaptor_get_stats (self);
 
   if (gst_structure_n_fields (s) != 0) {
     klass->on_stats (self, s);

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -52,6 +52,9 @@ void                    gaeguli_stream_adaptor_signal_encoding_parameters
                                                  const gchar                *param,
                                                  ...) G_GNUC_NULL_TERMINATED;
 
+GstStructure *          gaeguli_stream_adaptor_get_stats
+                                                (GaeguliStreamAdaptor       *self);
+
 G_END_DECLS
 
 #endif // __GAEGULI_STREAM_ADAPTOR_H__


### PR DESCRIPTION
_Gaeul Source Application_ needs to provide `get_stats` like D-Bus API to draw statistics graphs.
Rather accessing gaeguli pipeline directly to get `srtsink`, I think we can use public API to access the stats via streamadaptor.
But I am not sure if it fits @xhaakon's intention.