### PR TITLE
pipeline: factor out GaeguliTarget

### DIFF
--- a/gaeguli/adaptors/bandwidthadaptor.c
+++ b/gaeguli/adaptors/bandwidthadaptor.c
@@ -33,13 +33,12 @@ G_DEFINE_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_adaptor,
 
 GaeguliStreamAdaptor *
 gaeguli_bandwidth_stream_adaptor_new (GstElement * srtsink,
-    GstStructure * initial_encoding_params)
+    GstStructure * baseline_parameters)
 {
   g_return_val_if_fail (srtsink != NULL, NULL);
 
   return g_object_new (GAEGULI_TYPE_BANDWIDTH_STREAM_ADAPTOR,
-      "srtsink", srtsink,
-      "initial-encoding-parameters", initial_encoding_params, NULL);
+      "srtsink", srtsink, "baseline-parameters", baseline_parameters, NULL);
 }
 
 static void
@@ -86,7 +85,7 @@ gaeguli_bandwidth_stream_adaptor_constructed (GObject * object)
       GAEGULI_BANDWIDTH_STREAM_ADAPTOR (object);
 
   const GstStructure *initial_params =
-      gaeguli_stream_adaptor_get_initial_encoding_parameters
+      gaeguli_stream_adaptor_get_baseline_parameters
       (GAEGULI_STREAM_ADAPTOR (object));
 
   if (!gst_structure_get_uint (initial_params,

--- a/gaeguli/adaptors/bandwidthadaptor.h
+++ b/gaeguli/adaptors/bandwidthadaptor.h
@@ -30,7 +30,7 @@ G_DECLARE_FINAL_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_ad
 /**
  * gaeguli_bandwidth_stream_adaptor_new:
  * @srtsink: a #GstSrtSink element to collect data from
- * @initial_encoding_params: initial encoding parameters
+ * @baseline_parameters: baseline encoding parameters
  *
  * Creates a stream adaptor that adjusts stream bitrate to the measured
  * bandwidth of the network connection.
@@ -39,7 +39,7 @@ G_DECLARE_FINAL_TYPE (GaeguliBandwidthStreamAdaptor, gaeguli_bandwidth_stream_ad
  */
 GaeguliStreamAdaptor     *gaeguli_bandwidth_stream_adaptor_new
                                                 (GstElement            *srtsink,
-                                                 GstStructure          *initial_encoding_params);
+                                                 GstStructure          *baseline_parameters);
 
 G_END_DECLS
 

--- a/gaeguli/gaeguli.h
+++ b/gaeguli/gaeguli.h
@@ -24,6 +24,7 @@
 #include <gaeguli/types.h>
 #include <gaeguli/enumtypes.h>
 #include <gaeguli/pipeline.h>
+#include <gaeguli/target.h>
 #include <gaeguli/streamadaptor.h>
 
 #endif // __GAEGULI_H__

--- a/gaeguli/meson.build
+++ b/gaeguli/meson.build
@@ -6,12 +6,14 @@ configure_file(output: 'config.h', configuration: cdata)
 
 source_h = [
   'gaeguli.h',
+  'target.h',
   'types.h',
   'pipeline.h',
   'streamadaptor.h',
 ]
 
 source_c = [
+  'target.c',
   'types.c',
   'pipeline.c',
   'streamadaptor.c',

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -528,6 +528,8 @@ _build_target (GaeguliEncodingMethod encoding_method, GaeguliVideoCodec codec,
   g_signal_connect_swapped (target->adaptor, "encoding-parameters",
       (GCallback) _set_encoding_parameters, encoder);
 
+  gaeguli_stream_adaptor_start (target->adaptor);
+
   /* Setting READY state on srtsink check that we can bind to address and port
    * specified in srt_uri. On failure, bus handler should set internal_err. */
   res = gst_element_set_state (target->srtsink, GST_STATE_READY);

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -523,7 +523,7 @@ _build_target (GaeguliEncodingMethod encoding_method, GaeguliVideoCodec codec,
   encoder = gst_bin_get_by_name (GST_BIN (target->pipeline), "enc");
 
   target->adaptor = g_object_new (adaptor_type, "srtsink", target->srtsink,
-      "initial-encoding-parameters", _get_encoding_parameters (encoder), NULL);
+      "baseline-parameters", _get_encoding_parameters (encoder), NULL);
 
   g_signal_connect_swapped (target->adaptor, "encoding-parameters",
       (GCallback) _set_encoding_parameters, encoder);

--- a/gaeguli/pipeline.h
+++ b/gaeguli/pipeline.h
@@ -27,6 +27,8 @@
 #include <glib-object.h>
 #include <gaeguli/types.h>
 
+typedef struct _GaeguliTarget GaeguliTarget;
+
 /**
  * SECTION: pipeline
  * @Title: GaeguliPipeline
@@ -73,9 +75,10 @@ GaeguliPipeline        *gaeguli_pipeline_new_full
  *
  * Adds a SRT target to the pipeline.
  *
- * Returns: an identifier for the SRT connection known as target_id
+ * Returns: A #GageuliTarget. The object is owned by #GaeguliPipeline.
+ * You should g_object_ref() it to keep the reference.
  */
-guint                   gaeguli_pipeline_add_srt_target
+GaeguliTarget          *gaeguli_pipeline_add_srt_target
                                                 (GaeguliPipeline       *self,
                                                  const gchar           *uri,
                                                  const gchar           *username,
@@ -94,9 +97,10 @@ guint                   gaeguli_pipeline_add_srt_target
  *
  * Adds a SRT target to the pipeline using specific parameters.
  *
- * Returns: an identifier for the SRT connection known as target_id
+ * Returns: A #GageuliTarget. The object is owned by #GaeguliPipeline.
+ * You should g_object_ref() it to keep the reference.
  */
-guint                   gaeguli_pipeline_add_srt_target_full
+GaeguliTarget          *gaeguli_pipeline_add_srt_target_full
                                                 (GaeguliPipeline       *self,
                                                  GaeguliVideoCodec      codec,
                                                  GaeguliVideoResolution resolution,
@@ -107,20 +111,9 @@ guint                   gaeguli_pipeline_add_srt_target_full
                                                  GError               **error);
 
 /**
- * gaeguli_pipeline_target_get_bytes_sent:
- * @self: a #GaeguliPipeline object
- * @target_id: a SRT target as returned by #gaeguli_pipeline_add_srt_target
- *
- * Returns: the number of bytes sent over the given SRT target
- */
-guint64                 gaeguli_pipeline_target_get_bytes_sent
-                                                (GaeguliPipeline       *self,
-                                                 guint                  target_id);
-
-/**
  * gaeguli_pipeline_remove_target:
  * @self: a #GaeguliPipeline object
- * @target_id: identifier as returned by #gaeguli_pipeline_add_srt_target
+ * @target: the #GaeguliTarget to remove
  * @error: a #GError
  *
  * Removes a specific SRT target.
@@ -129,7 +122,7 @@ guint64                 gaeguli_pipeline_target_get_bytes_sent
  */
 GaeguliReturn           gaeguli_pipeline_remove_target
                                                 (GaeguliPipeline       *self,
-                                                 guint                  target_id,
+                                                 GaeguliTarget         *target,
                                                  GError               **error);
 
 /**

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -234,7 +234,7 @@ gaeguli_stream_adaptor_class_init (GaeguliStreamAdaptorClass * klass)
       g_param_spec_boxed ("baseline-parameters",
           "Baseline encoding parameters", "Baseline encoding parameters the "
           "adaptor derives its proposed modifications from", GST_TYPE_STRUCTURE,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_STATS_INTERVAL,
       g_param_spec_uint ("stats-interval", "Statistics collection interval",

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -23,7 +23,7 @@
 typedef struct
 {
   GstElement *srtsink;
-  GstStructure *initial_encoding_parameters;
+  GstStructure *baseline_parameters;
   guint stats_interval;
   guint stats_timeout_id;
 } GaeguliStreamAdaptorPrivate;
@@ -36,7 +36,7 @@ G_DEFINE_TYPE_WITH_PRIVATE (GaeguliStreamAdaptor, gaeguli_stream_adaptor,
 enum
 {
   PROP_SRTSINK = 1,
-  PROP_INITIAL_ENCODING_PARAMETERS,
+  PROP_BASELINE_PARAMETERS,
   PROP_STATS_INTERVAL,
   PROP_LAST
 };
@@ -114,8 +114,7 @@ gaeguli_stream_adaptor_set_stats_interval (GaeguliStreamAdaptor * self,
 }
 
 const GstStructure *
-gaeguli_stream_adaptor_get_initial_encoding_parameters (GaeguliStreamAdaptor *
-    self)
+gaeguli_stream_adaptor_get_baseline_parameters (GaeguliStreamAdaptor * self)
 {
   GaeguliStreamAdaptorPrivate *priv;
 
@@ -124,7 +123,7 @@ gaeguli_stream_adaptor_get_initial_encoding_parameters (GaeguliStreamAdaptor *
 
   priv = gaeguli_stream_adaptor_get_instance_private (self);
 
-  return priv->initial_encoding_parameters;
+  return priv->baseline_parameters;
 }
 
 void
@@ -159,8 +158,8 @@ gaeguli_stream_adaptor_set_property (GObject * object, guint property_id,
     case PROP_SRTSINK:
       gaeguli_stream_adaptor_set_srtsink (self, g_value_get_object (value));
       break;
-    case PROP_INITIAL_ENCODING_PARAMETERS:
-      priv->initial_encoding_parameters = g_value_dup_boxed (value);
+    case PROP_BASELINE_PARAMETERS:
+      priv->baseline_parameters = g_value_dup_boxed (value);
       break;
     case PROP_STATS_INTERVAL:
       gaeguli_stream_adaptor_set_stats_interval (self,
@@ -183,8 +182,8 @@ gaeguli_stream_adaptor_get_property (GObject * object, guint property_id,
     case PROP_SRTSINK:
       g_value_set_object (value, priv->srtsink);
       break;
-    case PROP_INITIAL_ENCODING_PARAMETERS:
-      g_value_set_boxed (value, priv->initial_encoding_parameters);
+    case PROP_BASELINE_PARAMETERS:
+      g_value_set_boxed (value, priv->baseline_parameters);
       break;
     case PROP_STATS_INTERVAL:
       g_value_set_uint (value, priv->stats_interval);
@@ -202,7 +201,7 @@ gaeguli_stream_adaptor_dispose (GObject * object)
       gaeguli_stream_adaptor_get_instance_private (self);
 
   gst_clear_object (&priv->srtsink);
-  gst_clear_structure (&priv->initial_encoding_parameters);
+  gst_clear_structure (&priv->baseline_parameters);
   g_clear_handle_id (&priv->stats_timeout_id, g_source_remove);
 
   G_OBJECT_CLASS (gaeguli_stream_adaptor_parent_class)->dispose (object);
@@ -222,11 +221,10 @@ gaeguli_stream_adaptor_class_init (GaeguliStreamAdaptorClass * klass)
           "SRT sink", GST_TYPE_ELEMENT,
           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class,
-      PROP_INITIAL_ENCODING_PARAMETERS,
-      g_param_spec_boxed ("initial-encoding-parameters",
-          "Initial encoding parameters", "Initial encoding parameters",
-          GST_TYPE_STRUCTURE,
+  g_object_class_install_property (gobject_class, PROP_BASELINE_PARAMETERS,
+      g_param_spec_boxed ("baseline-parameters",
+          "Baseline encoding parameters", "Baseline encoding parameters the "
+          "adaptor derives its proposed modifications from", GST_TYPE_STRUCTURE,
           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_STATS_INTERVAL,

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -126,6 +126,15 @@ gaeguli_stream_adaptor_get_baseline_parameters (GaeguliStreamAdaptor * self)
   return priv->baseline_parameters;
 }
 
+gboolean
+gaeguli_stream_adaptor_get_baseline_parameter_uint (GaeguliStreamAdaptor * self,
+    const gchar * name, guint * value)
+{
+  const GstStructure *s = gaeguli_stream_adaptor_get_baseline_parameters (self);
+
+  return gst_structure_get_uint (s, name, value);
+}
+
 void
 gaeguli_stream_adaptor_signal_encoding_parameters (GaeguliStreamAdaptor * self,
     const gchar * param, ...)

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -47,6 +47,11 @@ struct _GaeguliStreamAdaptorClass
 const GstStructure *    gaeguli_stream_adaptor_get_baseline_parameters
                                                 (GaeguliStreamAdaptor       *self);
 
+gboolean                gaeguli_stream_adaptor_get_baseline_parameter_uint
+                                                (GaeguliStreamAdaptor       *self,
+                                                 const gchar                *name,
+                                                 guint                      *value);
+
 void                    gaeguli_stream_adaptor_signal_encoding_parameters
                                                 (GaeguliStreamAdaptor       *self,
                                                  const gchar                *param,

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -44,7 +44,7 @@ struct _GaeguliStreamAdaptorClass
                                           GstStructure * stats);
 };
 
-const GstStructure *    gaeguli_stream_adaptor_get_initial_encoding_parameters
+const GstStructure *    gaeguli_stream_adaptor_get_baseline_parameters
                                                 (GaeguliStreamAdaptor       *self);
 
 void                    gaeguli_stream_adaptor_signal_encoding_parameters

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -1,0 +1,626 @@
+/**
+ *  Copyright 2019-2020 SK Telecom Co., Ltd.
+ *    Author: Jeongseok Kim <jeongseok.kim@sk.com>
+ *            Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "config.h"
+
+#include "target.h"
+
+#include "enumtypes.h"
+#include "gaeguli-internal.h"
+#include "pipeline.h"
+#include "streamadaptor.h"
+
+#include <gio/gio.h>
+
+typedef struct
+{
+  GObject parent;
+
+  GstElement *srtsink;
+  GstPad *peer_pad;
+  GstPad *sinkpad;
+  gulong pending_pad_probe;
+  GWeakRef gaeguli_pipeline;
+  GaeguliStreamAdaptor *adaptor;
+
+  GaeguliVideoCodec codec;
+  guint bitrate;
+  guint idr_period;
+  gchar *uri;
+  gchar *username;
+} GaeguliTargetPrivate;
+
+enum
+{
+  PROP_ID = 1,
+  PROP_PIPELINE,
+  PROP_CODEC,
+  PROP_BITRATE,
+  PROP_IDR_PERIOD,
+  PROP_URI,
+  PROP_USERNAME,
+};
+
+enum
+{
+  SIG_STREAM_STARTED,
+  SIG_STREAM_STOPPED,
+  LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = { 0 };
+
+static void gaeguli_target_initable_iface_init (GInitableIface * iface);
+
+/* *INDENT-OFF* */
+G_DEFINE_TYPE_WITH_CODE (GaeguliTarget, gaeguli_target, G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (GaeguliTarget)
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE,
+                                                gaeguli_target_initable_iface_init))
+/* *INDENT-ON* */
+
+static void
+gaeguli_target_init (GaeguliTarget * self)
+{
+}
+
+typedef gchar *(*PipelineFormatFunc) (const gchar * pipeline_str,
+    guint bitrate, guint idr_period);
+
+struct encoding_method_params
+{
+  const gchar *pipeline_str;
+  GaeguliEncodingMethod encoding_method;
+  GaeguliVideoCodec codec;
+  PipelineFormatFunc format_func;
+};
+
+static gchar *
+_format_general_pipeline (const gchar * pipeline_str, guint bitrate,
+    guint idr_period)
+{
+  /* x26[4,5]enc take bitrate in kbps. */
+  return g_strdup_printf (pipeline_str, bitrate / 1000, idr_period);
+}
+
+static gchar *
+_format_tx1_pipeline (const gchar * pipeline_str, guint bitrate,
+    guint idr_period)
+{
+  return g_strdup_printf (pipeline_str, bitrate, idr_period);
+}
+
+static struct encoding_method_params enc_params[] = {
+  {GAEGULI_PIPELINE_GENERAL_H264ENC_STR, GAEGULI_ENCODING_METHOD_GENERAL,
+      GAEGULI_VIDEO_CODEC_H264, _format_general_pipeline},
+  {GAEGULI_PIPELINE_GENERAL_H265ENC_STR, GAEGULI_ENCODING_METHOD_GENERAL,
+      GAEGULI_VIDEO_CODEC_H265, _format_general_pipeline},
+  {GAEGULI_PIPELINE_NVIDIA_TX1_H264ENC_STR, GAEGULI_ENCODING_METHOD_NVIDIA_TX1,
+      GAEGULI_VIDEO_CODEC_H264, _format_tx1_pipeline},
+  {GAEGULI_PIPELINE_NVIDIA_TX1_H265ENC_STR, GAEGULI_ENCODING_METHOD_NVIDIA_TX1,
+      GAEGULI_VIDEO_CODEC_H265, _format_tx1_pipeline},
+  {NULL, 0, 0},
+};
+
+static gchar *
+_get_enc_string (GaeguliEncodingMethod encoding_method,
+    GaeguliVideoCodec codec, guint bitrate, guint idr_period)
+{
+  struct encoding_method_params *params = enc_params;
+
+  for (; params->pipeline_str != NULL; params++) {
+    if (params->encoding_method == encoding_method && params->codec == codec)
+      return params->format_func (params->pipeline_str, bitrate, idr_period);
+  }
+
+  return NULL;
+}
+
+static GstBusSyncReply
+_bus_sync_srtsink_error_handler (GstBus * bus, GstMessage * message,
+    gpointer user_data)
+{
+  switch (message->type) {
+    case GST_MESSAGE_ERROR:{
+      g_autoptr (GError) error = NULL;
+      g_autofree gchar *debug = NULL;
+
+      gst_message_parse_error (message, &error, &debug);
+      if (g_error_matches (error, GST_RESOURCE_ERROR,
+              GST_RESOURCE_ERROR_OPEN_WRITE)) {
+        GError **error = user_data;
+
+        g_clear_error (error);
+
+        if (g_str_has_suffix (debug, "already listening on the same port")) {
+          *error = g_error_new (GAEGULI_TRANSMIT_ERROR,
+              GAEGULI_TRANSMIT_ERROR_ADDRINUSE, "Address already in use");
+        } else {
+          *error = g_error_new (GAEGULI_TRANSMIT_ERROR,
+              GAEGULI_TRANSMIT_ERROR_FAILED, "Failed to open SRT socket");
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return GST_BUS_PASS;
+}
+
+static GstStructure *
+_get_encoding_parameters (GstElement * encoder)
+{
+  g_autoptr (GstStructure) params =
+      gst_structure_new_empty ("application/x-gaeguli-encoding-parameters");
+
+  const gchar *encoder_type =
+      gst_plugin_feature_get_name (gst_element_get_factory (encoder));
+
+  if (g_str_equal (encoder_type, "x264enc")) {
+    guint bitrate = 0;
+    guint quantizer = 0;
+
+    g_object_get (encoder, "bitrate", &bitrate, "quantizer", &quantizer, NULL);
+
+    gst_structure_set (params,
+        GAEGULI_ENCODING_PARAMETER_BITRATE, G_TYPE_UINT, bitrate * 1000,
+        GAEGULI_ENCODING_PARAMETER_QUANTIZER, G_TYPE_UINT, quantizer, NULL);
+  } else if (g_str_equal (encoder_type, "x265enc")) {
+    guint bitrate = 0;
+
+    g_object_get (encoder, "bitrate", &bitrate, NULL);
+
+    gst_structure_set (params,
+        GAEGULI_ENCODING_PARAMETER_BITRATE, G_TYPE_UINT, bitrate * 1000, NULL);
+  } else {
+    g_warning ("Unsupported encoder '%s'", encoder_type);
+  }
+
+  return g_steal_pointer (&params);
+}
+
+static void
+_set_encoding_parameters (GstElement * encoder, GstStructure * params)
+{
+  guint val;
+  g_autofree gchar *params_str = NULL;
+
+  const gchar *encoder_type =
+      gst_plugin_feature_get_name (gst_element_get_factory (encoder));
+
+  params_str = gst_structure_to_string (params);
+  g_debug ("Changing encoding parameters to %s", params_str);
+
+  if (g_str_equal (encoder_type, "x264enc")) {
+    if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_BITRATE,
+            &val)) {
+      g_object_set (encoder, "bitrate", val / 1000, NULL);
+    }
+
+    if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_QUANTIZER,
+            &val)) {
+      gst_element_set_state (encoder, GST_STATE_READY);
+      g_object_set (encoder, "quantizer", val, NULL);
+      gst_element_set_state (encoder, GST_STATE_PLAYING);
+    }
+  } else if (g_str_equal (encoder_type, "x265enc")) {
+    if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_BITRATE,
+            &val)) {
+      g_object_set (encoder, "bitrate", val / 1000, NULL);
+    }
+  } else {
+    g_warning ("Unsupported encoder '%s'", encoder_type);
+  }
+}
+
+static gboolean
+gaeguli_target_initable_init (GInitable * initable, GCancellable * cancellable,
+    GError ** error)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (initable);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  g_autoptr (GaeguliPipeline) owner = NULL;
+  g_autoptr (GstElement) encoder = NULL;
+  g_autoptr (GstElement) enc_first = NULL;
+  g_autoptr (GstPad) enc_sinkpad = NULL;
+  g_autoptr (GstBus) bus = NULL;
+  g_autofree gchar *pipeline_str = NULL;
+  g_autofree gchar *uri_str = NULL;
+  g_autoptr (GError) internal_err = NULL;
+  GaeguliEncodingMethod encoding_method;
+  GType adaptor_type;
+  GstStateChangeReturn res;
+
+  owner = g_weak_ref_get (&priv->gaeguli_pipeline);
+  if (!owner) {
+    g_set_error (error, GAEGULI_RESOURCE_ERROR,
+        GAEGULI_RESOURCE_ERROR_UNSUPPORTED,
+        "Can't create a target without a pipeline");
+    return FALSE;
+  }
+
+  g_object_get (owner, "encoding-method", &encoding_method,
+      "stream-adaptor", &adaptor_type, NULL);
+
+  pipeline_str = _get_enc_string (encoding_method, priv->codec, priv->bitrate,
+      priv->idr_period);
+  if (pipeline_str == NULL) {
+    g_set_error (error, GAEGULI_RESOURCE_ERROR,
+        GAEGULI_RESOURCE_ERROR_UNSUPPORTED, "Can't determine encoding method");
+    return FALSE;
+  }
+
+  g_debug ("using encoding pipeline [%s]", pipeline_str);
+
+  if (priv->username) {
+    g_autoptr (GstUri) uri = gst_uri_from_string (priv->uri);
+    g_autofree gchar *streamid = g_strdup_printf ("#!::u=%s", priv->username);
+
+    gst_uri_set_query_value (uri, "streamid", streamid);
+    uri_str = gst_uri_to_string (uri);
+  }
+
+  pipeline_str = g_strdup_printf ("%s ! " GAEGULI_PIPELINE_MUXSINK_STR,
+      pipeline_str, uri_str ? uri_str : priv->uri);
+
+  self->pipeline = gst_parse_launch (pipeline_str, &internal_err);
+  if (internal_err) {
+    g_warning ("failed to build muxsink pipeline (%s)", internal_err->message);
+    goto failed;
+  }
+
+  gst_object_ref_sink (self->pipeline);
+
+  priv->srtsink = gst_bin_get_by_name (GST_BIN (self->pipeline), "sink");
+  g_object_set_data (G_OBJECT (priv->srtsink), "gaeguli-target-id",
+      GUINT_TO_POINTER (self->id));
+
+  bus = gst_element_get_bus (self->pipeline);
+  gst_bus_set_sync_handler (bus, _bus_sync_srtsink_error_handler, &internal_err,
+      NULL);
+
+  encoder = gst_bin_get_by_name (GST_BIN (self->pipeline), "enc");
+
+  priv->adaptor = g_object_new (adaptor_type, "srtsink", priv->srtsink,
+      "baseline-parameters", _get_encoding_parameters (encoder), NULL);
+
+  g_signal_connect_swapped (priv->adaptor, "encoding-parameters",
+      (GCallback) _set_encoding_parameters, encoder);
+
+  /* Setting READY state on srtsink check that we can bind to address and port
+   * specified in srt_uri. On failure, bus handler should set internal_err. */
+  res = gst_element_set_state (priv->srtsink, GST_STATE_READY);
+
+  gst_bus_set_sync_handler (bus, NULL, NULL, NULL);
+
+  if (res == GST_STATE_CHANGE_FAILURE) {
+    goto failed;
+  }
+
+  enc_first = gst_bin_get_by_name (GST_BIN (self->pipeline), "enc_first");
+  enc_sinkpad = gst_element_get_static_pad (enc_first, "sink");
+
+  priv->sinkpad = gst_ghost_pad_new (NULL, enc_sinkpad);
+  gst_object_ref_sink (priv->sinkpad);
+  gst_element_add_pad (self->pipeline, priv->sinkpad);
+
+  return TRUE;
+
+failed:
+  if (internal_err) {
+    g_propagate_error (error, internal_err);
+    internal_err = NULL;
+  }
+
+  return FALSE;
+}
+
+static void
+gaeguli_target_get_property (GObject * object,
+    guint prop_id, GValue * value, GParamSpec * pspec)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (object);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  switch (prop_id) {
+    case PROP_ID:
+      g_value_set_uint (value, self->id);
+      break;
+    case PROP_BITRATE:
+      g_value_set_uint (value, priv->bitrate);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gaeguli_target_set_property (GObject * object,
+    guint prop_id, const GValue * value, GParamSpec * pspec)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (object);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  switch (prop_id) {
+    case PROP_ID:
+      self->id = g_value_get_uint (value);
+      break;
+    case PROP_PIPELINE:
+      g_weak_ref_init (&priv->gaeguli_pipeline, g_value_get_object (value));
+      break;
+    case PROP_CODEC:
+      priv->codec = g_value_get_enum (value);
+      break;
+    case PROP_BITRATE:
+      priv->bitrate = g_value_get_uint (value);
+      break;
+    case PROP_IDR_PERIOD:
+      priv->idr_period = g_value_get_uint (value);
+      break;
+    case PROP_URI:
+      priv->uri = g_value_dup_string (value);
+      break;
+    case PROP_USERNAME:
+      priv->username = g_value_dup_string (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+gaeguli_target_dispose (GObject * object)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (object);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  gst_clear_object (&self->pipeline);
+  gst_clear_object (&priv->srtsink);
+  gst_clear_object (&priv->peer_pad);
+  gst_clear_object (&priv->sinkpad);
+
+  g_weak_ref_clear (&priv->gaeguli_pipeline);
+  g_clear_object (&priv->adaptor);
+
+  g_clear_pointer (&priv->uri, g_free);
+  g_clear_pointer (&priv->username, g_free);
+
+  G_OBJECT_CLASS (gaeguli_target_parent_class)->dispose (object);
+}
+
+static void
+gaeguli_target_class_init (GaeguliTargetClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->get_property = gaeguli_target_get_property;
+  gobject_class->set_property = gaeguli_target_set_property;
+  gobject_class->dispose = gaeguli_target_dispose;
+
+  g_object_class_install_property (gobject_class, PROP_ID,
+      g_param_spec_uint ("id", "target ID", "target ID",
+          0, G_MAXUINT, 0,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_PIPELINE,
+      g_param_spec_object ("pipeline", "owning GaeguliPipeline instance",
+          "owning GaeguliPipeline instance", GAEGULI_TYPE_PIPELINE,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_CODEC,
+      g_param_spec_enum ("codec", "video codec", "video codec",
+          GAEGULI_TYPE_VIDEO_CODEC, DEFAULT_VIDEO_CODEC,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_BITRATE,
+      g_param_spec_uint ("bitrate", "video bitrate", "video bitrate",
+          1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_IDR_PERIOD,
+      g_param_spec_uint ("idr-period", "keyframe interval",
+          "Maximal distance between two key-frames (0 for automatic)",
+          0, G_MAXUINT, 0,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_URI,
+      g_param_spec_string ("uri", "SRT URI", "SRT URI",
+          NULL,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_USERNAME,
+      g_param_spec_string ("username", "username", "username",
+          NULL,
+          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+
+  signals[SIG_STREAM_STARTED] =
+      g_signal_new ("stream-started", G_TYPE_FROM_CLASS (klass),
+      G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS, 0, NULL,
+      NULL, NULL, G_TYPE_NONE, 0);
+
+  signals[SIG_STREAM_STOPPED] =
+      g_signal_new ("stream-stopped", G_TYPE_FROM_CLASS (klass),
+      G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS, 0, NULL,
+      NULL, NULL, G_TYPE_NONE, 0);
+}
+
+static void
+gaeguli_target_initable_iface_init (GInitableIface * iface)
+{
+  iface->init = gaeguli_target_initable_init;
+}
+
+GaeguliTarget *
+gaeguli_target_new (GaeguliPipeline * pipeline, guint id,
+    GaeguliVideoCodec codec, guint bitrate, guint idr_period,
+    const gchar * srt_uri, const gchar * username, GError ** error)
+{
+  return g_initable_new (GAEGULI_TYPE_TARGET, NULL, error, "id", id,
+      "pipeline", pipeline, "codec", codec, "bitrate", bitrate,
+      "idr-period", idr_period, "uri", srt_uri, "username", username, NULL);
+}
+
+static GstPadProbeReturn
+_link_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (user_data);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  GstPad *ghost_pad = NULL;
+
+  /*
+   * GST_PAD_PROBE_TYPE_IDLE can cause infinite waiting in filesink.
+   * In addition, to prevent events generated in gst_ghost_pad_new()
+   * from invoking this probe callback again, we remove the probe first.
+   *
+   * For more details, refer to
+   * https://github.com/hwangsaeul/gaeguli/pull/10#discussion_r327031325
+   */
+  gst_pad_remove_probe (pad, info->id);
+
+  if (priv->pending_pad_probe == info->id) {
+    priv->pending_pad_probe = 0;
+  }
+
+  g_debug ("start link target [%x]", self->id);
+
+  ghost_pad = gst_ghost_pad_new (NULL, priv->peer_pad);
+  if (ghost_pad == NULL) {
+    g_error ("ghost pad is null");
+  }
+
+  gst_element_add_pad (GST_ELEMENT_PARENT (GST_PAD_PARENT (priv->peer_pad)),
+      ghost_pad);
+
+  gst_element_sync_state_with_parent (self->pipeline);
+  if (gst_pad_link (ghost_pad, priv->sinkpad) != GST_PAD_LINK_OK) {
+    g_error ("failed to link target to Gaeguli pipeline");
+  }
+
+  g_signal_emit (self, signals[SIG_STREAM_STARTED], 0);
+
+  return GST_PAD_PROBE_REMOVE;
+}
+
+void
+gaeguli_target_link_with_pad (GaeguliTarget * self, GstPad * pad)
+{
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  priv->peer_pad = gst_object_ref (pad);
+
+  priv->pending_pad_probe = gst_pad_add_probe (priv->peer_pad,
+      GST_PAD_PROBE_TYPE_BLOCK, _link_probe_cb, self, NULL);
+}
+
+guint64
+gaeguli_target_get_bytes_sent (GaeguliTarget * self)
+{
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  g_autoptr (GstStructure) s = NULL;
+  guint64 result = 0;
+
+  g_return_val_if_fail (GAEGULI_IS_TARGET (self), GAEGULI_RETURN_FAIL);
+
+  if (priv->srtsink) {
+    g_object_get (priv->srtsink, "stats", &s, NULL);
+    gst_structure_get_uint64 (s, "bytes-sent", &result);
+  } else {
+    g_warning ("SRT sink for target %d not found", self->id);
+  }
+
+  return result;
+}
+
+static gboolean
+_unlink_finish_in_main_thread (GaeguliTarget * self)
+{
+  g_return_val_if_fail (self != NULL, G_SOURCE_REMOVE);
+
+  gst_element_set_state (self->pipeline, GST_STATE_NULL);
+
+  g_signal_emit (self, signals[SIG_STREAM_STOPPED], 0);
+
+  return G_SOURCE_REMOVE;
+}
+
+static GstPadProbeReturn
+_unlink_probe_cb (GstPad * pad, GstPadProbeInfo * info, gpointer user_data)
+{
+  GaeguliTarget *self = GAEGULI_TARGET (user_data);
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  g_autoptr (GstElement) topmost_pipeline = NULL;
+  g_autoptr (GstPad) ghost_srcpad = NULL;
+
+  /* Remove the probe first. See _link_probe_cb() for details. */
+  gst_pad_remove_probe (pad, info->id);
+
+  if (priv->pending_pad_probe == info->id) {
+    priv->pending_pad_probe = 0;
+  }
+
+  ghost_srcpad = gst_pad_get_peer (priv->sinkpad);
+
+  g_debug ("start unlink target [%x]", self->id);
+
+  if (!gst_pad_unlink (ghost_srcpad, priv->sinkpad)) {
+    g_error ("failed to unlink");
+  }
+
+  gst_ghost_pad_set_target (GST_GHOST_PAD (ghost_srcpad), NULL);
+  gst_element_remove_pad (GST_PAD_PARENT (ghost_srcpad), ghost_srcpad);
+  gst_element_release_request_pad (GST_PAD_PARENT (priv->peer_pad),
+      priv->peer_pad);
+
+  topmost_pipeline =
+      GST_ELEMENT (gst_object_get_parent (GST_OBJECT (self->pipeline)));
+  gst_bin_remove (GST_BIN (topmost_pipeline), self->pipeline);
+
+  /* This probe may get called from the target's streaming thread, so let the
+   * state change happen in the main thread. */
+  g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
+      (GSourceFunc) _unlink_finish_in_main_thread,
+      g_object_ref (self), g_object_unref);
+
+  return GST_PAD_PROBE_REMOVE;
+}
+
+void
+gaeguli_target_unlink (GaeguliTarget * self)
+{
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  if (priv->pending_pad_probe != 0) {
+    /* Target removed before its link pad probe got called. */
+    gst_pad_remove_probe (priv->peer_pad, priv->pending_pad_probe);
+    priv->pending_pad_probe = 0;
+  } else {
+    gst_element_set_state (priv->srtsink, GST_STATE_NULL);
+
+    gst_pad_add_probe (priv->peer_pad, GST_PAD_PROBE_TYPE_BLOCK,
+        _unlink_probe_cb, g_object_ref (self), (GDestroyNotify) g_object_unref);
+  }
+}

--- a/gaeguli/target.h
+++ b/gaeguli/target.h
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2019-2020 SK Telecom Co., Ltd.
+ *    Author: Jeongseok Kim <jeongseok.kim@sk.com>
+ *            Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef __GAEGULI_TARGET_H__
+#define __GAEGULI_TARGET_H__
+
+#if !defined(__GAEGULI_INSIDE__) && !defined(GAEGULI_COMPILATION)
+#error "Only <gaeguli/gaeguli.h> can be included directly."
+#endif
+
+#include <gst/gst.h>
+#include <gaeguli/types.h>
+
+typedef struct _GaeguliPipeline GaeguliPipeline;
+
+/**
+ * SECTION: target
+ * @Title: GaeguliTarget
+ * @Short_description: A SRT stream source
+ *
+ * A #GaeguliTarget represents an encoded video stream available on a defined
+ * UDP port for consumption by clients connecting using SRT protocol.
+ */
+
+G_BEGIN_DECLS
+
+#define GAEGULI_TYPE_TARGET   (gaeguli_target_get_type ())
+G_DECLARE_FINAL_TYPE          (GaeguliTarget, gaeguli_target, GAEGULI, TARGET, GObject)
+
+struct _GaeguliTarget
+{
+  GObject parent;
+
+  guint id;
+  GstElement *pipeline;
+};
+
+
+GaeguliTarget          *gaeguli_target_new           (GaeguliPipeline       *owner,
+                                                      guint                  id,
+                                                      GaeguliVideoCodec      codec,
+                                                      guint                  bitrate,
+                                                      guint                  idr_period,
+                                                      const gchar           *srt_uri,
+                                                      const gchar           *username,
+                                                      GError               **error);
+
+void                    gaeguli_target_link_with_pad (GaeguliTarget        *self,
+                                                      GstPad               *pad);
+
+void                    gaeguli_target_unlink        (GaeguliTarget        *self);
+
+/**
+ * gaeguli_pipeline_target_get_bytes_sent:
+ * @self: a #GaeguliPipeline object
+ * @target_id: a SRT target as returned by #gaeguli_pipeline_add_srt_target
+ *
+ * Returns: the number of bytes sent over the given SRT target
+ */
+guint64                 gaeguli_target_get_bytes_sent (GaeguliTarget       *self);
+
+G_END_DECLS
+
+#endif // __GAEGULI_TARGET_H__

--- a/tests/test-adaptor.c
+++ b/tests/test-adaptor.c
@@ -153,24 +153,24 @@ gaeguli_test_adaptor_init (GaeguliTestAdaptor * self)
 static void
 gaeguli_test_adaptor_constructed (GObject * self)
 {
-  const GstStructure *initial_params = NULL;
+  const GstStructure *baseline_params = NULL;
   guint val;
 
   g_object_set (self, "stats-interval", STATS_INTERVAL_MS, NULL);
 
-  initial_params = gaeguli_stream_adaptor_get_initial_encoding_parameters
+  baseline_params = gaeguli_stream_adaptor_get_baseline_parameters
       (GAEGULI_STREAM_ADAPTOR (self));
 
-  g_assert_cmpstr (gst_structure_get_name (initial_params), ==,
+  g_assert_cmpstr (gst_structure_get_name (baseline_params), ==,
       "application/x-gaeguli-encoding-parameters");
 
-  g_assert_true (gst_structure_has_field (initial_params,
+  g_assert_true (gst_structure_has_field (baseline_params,
           GAEGULI_ENCODING_PARAMETER_BITRATE));
-  g_assert_true (gst_structure_get_uint (initial_params,
+  g_assert_true (gst_structure_get_uint (baseline_params,
           GAEGULI_ENCODING_PARAMETER_BITRATE, &val));
   g_assert_cmpint (val, ==, TEST_BITRATE2 - (TEST_BITRATE2 % 1000));
 
-  g_assert_true (gst_structure_has_field (initial_params,
+  g_assert_true (gst_structure_has_field (baseline_params,
           GAEGULI_ENCODING_PARAMETER_QUANTIZER));
 }
 

--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -13,7 +13,7 @@
 #include <gst/gst.h>
 
 static guint signal_watch_intr_id;
-static guint target_id;
+static GaeguliTarget *target;
 
 static struct
 {
@@ -33,7 +33,7 @@ activate (GApplication * app, gpointer user_data)
   g_application_hold (app);
 
   g_print ("Streaming to %s\n", options.uri);
-  target_id = gaeguli_pipeline_add_srt_target (pipeline, options.uri,
+  target = gaeguli_pipeline_add_srt_target (pipeline, options.uri,
       options.username, &error);
 }
 
@@ -43,7 +43,7 @@ intr_handler (gpointer user_data)
   GaeguliPipeline *pipeline = user_data;
   g_autoptr (GError) error = NULL;
 
-  gaeguli_pipeline_remove_target (pipeline, target_id, &error);
+  gaeguli_pipeline_remove_target (pipeline, target, &error);
 
   g_debug ("target removed");
 


### PR DESCRIPTION
Move GaeguliTarget into its own file and make it a full-fledged GObject.

gaeguli_pipeline_add_srt_target(_full) & gaeguli_pipeline_remove_target
now return and accept GaeguliTarget instance respectively. The original
target ID, though less prominent now, still exists in the target
structure in case it's needed.