### PR TITLE
target: manual encoder settings

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -32,11 +32,11 @@
         tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
-        queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency bitrate=%d key-int-max=%d ! \
+        queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency key-int-max=%d ! \
         h264parse ! queue "
 
 #define GAEGULI_PIPELINE_GENERAL_H265ENC_STR    "\
-        queue name=enc_first ! videoconvert ! x265enc name=enc tune=zerolatency bitrate=%d key-int-max=%d ! \
+        queue name=enc_first ! videoconvert ! x265enc name=enc tune=zerolatency key-int-max=%d ! \
         h265parse ! queue "
 
 /* nvidia tx1 pipeline (for v4l2src) */
@@ -46,11 +46,11 @@
 
 #define GAEGULI_PIPELINE_NVIDIA_TX1_H264ENC_STR    "\
         queue name=enc_first ! nvvidconv ! video/x-raw(memory:NVMM),format=I420 ! \
-        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d periodicity-idr=%d ! queue "
+        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 periodicity-idr=%d ! queue "
 
 #define GAEGULI_PIPELINE_NVIDIA_TX1_H265ENC_STR    "\
         queue name=enc_first ! nvvidconv ! video/x-raw(memory:NVMM),format=I420 ! \
-        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 bitrate=%d periodicity-idr=%d ! queue "
+        omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 periodicity-idr=%d ! queue "
 
 #define GAEGULI_PIPELINE_MUXSINK_STR    "\
         mpegtsmux name=muxsink_first ! tsparse set-timestamps=1 smoothing-latency=1000 ! \

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -41,6 +41,7 @@ typedef struct
 
   GaeguliVideoCodec codec;
   guint bitrate;
+  guint quantizer;
   guint idr_period;
   gchar *uri;
   gchar *username;
@@ -53,6 +54,7 @@ enum
   PROP_PIPELINE,
   PROP_CODEC,
   PROP_BITRATE,
+  PROP_QUANTIZER,
   PROP_IDR_PERIOD,
   PROP_URI,
   PROP_USERNAME,
@@ -351,6 +353,9 @@ gaeguli_target_get_property (GObject * object,
     case PROP_BITRATE:
       g_value_set_uint (value, priv->bitrate);
       break;
+    case PROP_QUANTIZER:
+      g_value_set_uint (value, priv->quantizer);
+      break;
     case PROP_ADAPTIVE_STREAMING:
       g_value_set_boolean (value, priv->adaptive_streaming);
       break;
@@ -379,6 +384,9 @@ gaeguli_target_set_property (GObject * object,
       break;
     case PROP_BITRATE:
       priv->bitrate = g_value_get_uint (value);
+      break;
+    case PROP_QUANTIZER:
+      priv->quantizer = g_value_get_uint (value);
       break;
     case PROP_IDR_PERIOD:
       priv->idr_period = g_value_get_uint (value);
@@ -448,6 +456,12 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
   g_object_class_install_property (gobject_class, PROP_BITRATE,
       g_param_spec_uint ("bitrate", "video bitrate", "video bitrate",
           1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_QUANTIZER,
+      g_param_spec_uint ("quantizer", "Constant quantizer or quality to apply",
+          "Constant quantizer or quality to apply",
+          1, G_MAXUINT, 21,
           G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_IDR_PERIOD,

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -219,9 +219,16 @@ _set_encoding_parameters (GstElement * encoder, GstStructure * params)
 
     if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_QUANTIZER,
             &val)) {
-      gst_element_set_state (encoder, GST_STATE_READY);
+      GstState cur_state;
+
+      gst_element_get_state (encoder, &cur_state, NULL, 0);
+      if (cur_state == GST_STATE_PLAYING) {
+        gst_element_set_state (encoder, GST_STATE_READY);
+      }
       g_object_set (encoder, "quantizer", val, NULL);
-      gst_element_set_state (encoder, GST_STATE_PLAYING);
+      if (cur_state == GST_STATE_PLAYING) {
+        gst_element_set_state (encoder, GST_STATE_PLAYING);
+      }
     }
   } else if (g_str_equal (encoder_type, "x265enc")) {
     if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_BITRATE,

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -219,15 +219,21 @@ _set_encoding_parameters (GstElement * encoder, GstStructure * params)
 
     if (gst_structure_get_uint (params, GAEGULI_ENCODING_PARAMETER_QUANTIZER,
             &val)) {
-      GstState cur_state;
+      guint cur_quantizer;
 
-      gst_element_get_state (encoder, &cur_state, NULL, 0);
-      if (cur_state == GST_STATE_PLAYING) {
-        gst_element_set_state (encoder, GST_STATE_READY);
-      }
-      g_object_set (encoder, "quantizer", val, NULL);
-      if (cur_state == GST_STATE_PLAYING) {
-        gst_element_set_state (encoder, GST_STATE_PLAYING);
+      g_object_get (encoder, "quantizer", &cur_quantizer, NULL);
+
+      if (val != cur_quantizer) {
+        GstState cur_state;
+
+        gst_element_get_state (encoder, &cur_state, NULL, 0);
+        if (cur_state == GST_STATE_PLAYING) {
+          gst_element_set_state (encoder, GST_STATE_READY);
+        }
+        g_object_set (encoder, "quantizer", val, NULL);
+        if (cur_state == GST_STATE_PLAYING) {
+          gst_element_set_state (encoder, GST_STATE_PLAYING);
+        }
       }
     }
   } else if (g_str_equal (encoder_type, "x265enc")) {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,6 +3,7 @@ subdir('common')
 tests = [
   'test-pipeline',
   'test-adaptor',
+  'test-target',
 ]
 
 foreach t: tests

--- a/tests/test-target.c
+++ b/tests/test-target.c
@@ -1,0 +1,76 @@
+/**
+ *  tests/test-target
+ *
+ *  Copyright 2020 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include <gaeguli/gaeguli.h>
+
+#define DEFAULT_BITRATE 1500000
+#define CHANGED_BITRATE 3000000
+#define ROUNDED_BITRATE 9999999
+
+
+static void
+test_gaeguli_target_encoding_params ()
+{
+  g_autoptr (GaeguliPipeline) pipeline = NULL;
+  g_autoptr (GError) error = NULL;
+  GaeguliTarget *target;
+  guint val;
+
+  pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_ENCODING_METHOD_GENERAL);
+
+  target = gaeguli_pipeline_add_srt_target_full (pipeline,
+      GAEGULI_VIDEO_CODEC_H264, GAEGULI_VIDEO_RESOLUTION_640X480, 15,
+      DEFAULT_BITRATE, "srt://127.0.0.1:1111", NULL, &error);
+  g_assert_no_error (error);
+
+  g_object_get (target, "bitrate", &val, NULL);
+  g_assert_cmpuint (val, ==, DEFAULT_BITRATE);
+  g_object_get (target, "bitrate-actual", &val, NULL);
+  g_assert_cmpuint (val, ==, DEFAULT_BITRATE);
+
+  g_object_set (target, "bitrate", CHANGED_BITRATE, NULL);
+  g_object_get (target, "bitrate", &val, NULL);
+  g_assert_cmpuint (val, ==, CHANGED_BITRATE);
+  g_object_get (target, "bitrate-actual", &val, NULL);
+  g_assert_cmpuint (val, ==, CHANGED_BITRATE);
+
+  g_object_set (target, "bitrate", ROUNDED_BITRATE, NULL);
+  g_object_get (target, "bitrate", &val, NULL);
+  g_assert_cmpuint (val, ==, ROUNDED_BITRATE);
+  g_object_get (target, "bitrate-actual", &val, NULL);
+  /* Internally, x264enc accepts bitrate in kbps, so we lose the value precision
+   * in the three least significant digits. */
+  g_assert_cmpuint (val, ==, ROUNDED_BITRATE - (ROUNDED_BITRATE % 1000));
+
+  gaeguli_pipeline_stop (pipeline);
+}
+
+int
+main (int argc, char *argv[])
+{
+  gst_init (&argc, &argv);
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/gaeguli/target-encoding-params",
+      test_gaeguli_target_encoding_params);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
Adds some new properties to `GaeguliTarget`:

* boolean `"adaptive-streaming"` allowing to turn stream adaptor on or off
* `"bitrate"` and `"quantizer"` that can be manually changed at runtime
* read-only `"bitrate-actual"` and `"quantizer-actual"` give access to the encoder settings in effect, which may be different from user settings due to modifications imposed by adaptive streaming.