### PR TITLE
target: explicity notify on "bitrate" and "quantizer" property change

### DIFF
--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -116,6 +116,15 @@ gaeguli_stream_adaptor_set_stats_interval (GaeguliStreamAdaptor * self,
   }
 }
 
+gboolean
+gaeguli_stream_adaptor_is_enabled (GaeguliStreamAdaptor * self)
+{
+  GaeguliStreamAdaptorPrivate *priv =
+      gaeguli_stream_adaptor_get_instance_private (self);
+
+  return priv->stats_timeout_id != 0;
+}
+
 const GstStructure *
 gaeguli_stream_adaptor_get_baseline_parameters (GaeguliStreamAdaptor * self)
 {
@@ -212,7 +221,7 @@ gaeguli_stream_adaptor_get_property (GObject * object, guint property_id,
       g_value_set_uint (value, priv->stats_interval);
       break;
     case PROP_ENABLED:
-      g_value_set_boolean (value, priv->stats_timeout_id != 0);
+      g_value_set_boolean (value, gaeguli_stream_adaptor_is_enabled (self));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -44,6 +44,9 @@ struct _GaeguliStreamAdaptorClass
                                           GstStructure * stats);
 };
 
+gboolean                gaeguli_stream_adaptor_is_enabled
+                                                (GaeguliStreamAdaptor       *self);
+
 const GstStructure *    gaeguli_stream_adaptor_get_baseline_parameters
                                                 (GaeguliStreamAdaptor       *self);
 

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -271,7 +271,7 @@ gaeguli_target_update_baseline_parameters (GaeguliTarget * self,
     g_object_set (priv->adaptor, "baseline-parameters", params, NULL);
   }
 
-  if (priv->adaptive_streaming == FALSE || force_on_encoder) {
+  if (!gaeguli_stream_adaptor_is_enabled (priv->adaptor) || force_on_encoder) {
     /* Apply directly on the encoder */
     _set_encoding_parameters (priv->encoder, params);
   }
@@ -434,6 +434,10 @@ gaeguli_target_get_property (GObject * object,
               GAEGULI_ENCODING_PARAMETER_QUANTIZER));
       break;
     case PROP_ADAPTIVE_STREAMING:
+      if (priv->adaptor) {
+        priv->adaptive_streaming =
+            gaeguli_stream_adaptor_is_enabled (priv->adaptor);
+      }
       g_value_set_boolean (value, priv->adaptive_streaming);
       break;
     default:

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -271,7 +271,7 @@ gaeguli_target_update_baseline_parameters (GaeguliTarget * self,
     g_object_set (priv->adaptor, "baseline-parameters", params, NULL);
   }
 
-  if (priv->adaptive_streaming || force_on_encoder) {
+  if (priv->adaptive_streaming == FALSE || force_on_encoder) {
     /* Apply directly on the encoder */
     _set_encoding_parameters (priv->encoder, params);
   }

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -62,7 +62,10 @@ enum
   PROP_URI,
   PROP_USERNAME,
   PROP_ADAPTIVE_STREAMING,
+  PROP_LAST
 };
+
+static GParamSpec *properties[PROP_LAST] = { 0 };
 
 enum
 {
@@ -498,65 +501,66 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
   gobject_class->set_property = gaeguli_target_set_property;
   gobject_class->dispose = gaeguli_target_dispose;
 
-  g_object_class_install_property (gobject_class, PROP_ID,
+  properties[PROP_ID] =
       g_param_spec_uint ("id", "target ID", "target ID",
-          0, G_MAXUINT, 0,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      0, G_MAXUINT, 0,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_PIPELINE,
+  properties[PROP_PIPELINE] =
       g_param_spec_object ("pipeline", "owning GaeguliPipeline instance",
-          "owning GaeguliPipeline instance", GAEGULI_TYPE_PIPELINE,
-          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      "owning GaeguliPipeline instance", GAEGULI_TYPE_PIPELINE,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_CODEC,
+  properties[PROP_CODEC] =
       g_param_spec_enum ("codec", "video codec", "video codec",
-          GAEGULI_TYPE_VIDEO_CODEC, DEFAULT_VIDEO_CODEC,
-          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      GAEGULI_TYPE_VIDEO_CODEC, DEFAULT_VIDEO_CODEC,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_BITRATE,
+  properties[PROP_BITRATE] =
       g_param_spec_uint ("bitrate", "requested video bitrate",
-          "requested video bitrate", 1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
-          G_PARAM_STATIC_STRINGS));
+      "requested video bitrate", 1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
+      G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_BITRATE_ACTUAL,
+  properties[PROP_BITRATE_ACTUAL] =
       g_param_spec_uint ("bitrate-actual", "actual video bitrate",
-          "actual video bitrate", 1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
-          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+      "actual video bitrate", 1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
+      G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_QUANTIZER,
+  properties[PROP_QUANTIZER] =
       g_param_spec_uint ("quantizer", "Constant quantizer or quality to apply",
-          "Constant quantizer or quality to apply",
-          1, G_MAXUINT, 21,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
-          G_PARAM_STATIC_STRINGS));
+      "Constant quantizer or quality to apply",
+      1, G_MAXUINT, 21,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
+      G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_QUANTIZER_ACTUAL,
+  properties[PROP_QUANTIZER_ACTUAL] =
       g_param_spec_uint ("quantizer-actual",
-          "Actual constant quantizer or quality used",
-          "Actual constant quantizer or quality used", 0, G_MAXUINT, 0,
-          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+      "Actual constant quantizer or quality used",
+      "Actual constant quantizer or quality used", 0, G_MAXUINT, 0,
+      G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_IDR_PERIOD,
+  properties[PROP_IDR_PERIOD] =
       g_param_spec_uint ("idr-period", "keyframe interval",
-          "Maximal distance between two key-frames (0 for automatic)",
-          0, G_MAXUINT, 0,
-          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      "Maximal distance between two key-frames (0 for automatic)",
+      0, G_MAXUINT, 0,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_URI,
+  properties[PROP_URI] =
       g_param_spec_string ("uri", "SRT URI", "SRT URI",
-          NULL,
-          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      NULL, G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_USERNAME,
+  properties[PROP_USERNAME] =
       g_param_spec_string ("username", "username", "username",
-          NULL,
-          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+      NULL, G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
-  g_object_class_install_property (gobject_class, PROP_ADAPTIVE_STREAMING,
+  properties[PROP_ADAPTIVE_STREAMING] =
       g_param_spec_boolean ("adaptive-streaming", "Use adaptive streaming",
-          "Use adaptive streaming", TRUE,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+      "Use adaptive streaming", TRUE,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (gobject_class, G_N_ELEMENTS (properties),
+      properties);
 
   signals[SIG_STREAM_STARTED] =
       g_signal_new ("stream-started", G_TYPE_FROM_CLASS (klass),

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -429,14 +429,24 @@ gaeguli_target_set_property (GObject * object,
     case PROP_CODEC:
       priv->codec = g_value_get_enum (value);
       break;
-    case PROP_BITRATE:
-      priv->bitrate = g_value_get_uint (value);
-      gaeguli_target_update_baseline_parameters (self, FALSE);
+    case PROP_BITRATE:{
+      guint new_bitrate = g_value_get_uint (value);
+      if (priv->bitrate != new_bitrate) {
+        priv->bitrate = new_bitrate;
+        gaeguli_target_update_baseline_parameters (self, FALSE);
+        g_object_notify_by_pspec (object, pspec);
+      }
       break;
-    case PROP_QUANTIZER:
-      priv->quantizer = g_value_get_uint (value);
-      gaeguli_target_update_baseline_parameters (self, FALSE);
+    }
+    case PROP_QUANTIZER:{
+      guint new_quantizer = g_value_get_uint (value);
+      if (priv->quantizer != new_quantizer) {
+        priv->quantizer = new_quantizer;
+        gaeguli_target_update_baseline_parameters (self, FALSE);
+        g_object_notify_by_pspec (object, pspec);
+      }
       break;
+    }
     case PROP_IDR_PERIOD:
       priv->idr_period = g_value_get_uint (value);
       break;
@@ -506,7 +516,8 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
   g_object_class_install_property (gobject_class, PROP_BITRATE,
       g_param_spec_uint ("bitrate", "requested video bitrate",
           "requested video bitrate", 1, G_MAXUINT, DEFAULT_VIDEO_BITRATE,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
+          G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_BITRATE_ACTUAL,
       g_param_spec_uint ("bitrate-actual", "actual video bitrate",
@@ -517,7 +528,8 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
       g_param_spec_uint ("quantizer", "Constant quantizer or quality to apply",
           "Constant quantizer or quality to apply",
           1, G_MAXUINT, 21,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+          G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
+          G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_QUANTIZER_ACTUAL,
       g_param_spec_uint ("quantizer-actual",


### PR DESCRIPTION
Emitting "notify" only when the property value really changes avoids
infinite loops when the value is modified over D-Bus.

