### PR TITLE
target: fix changing quantizer at runtime

### DIFF
--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -561,7 +561,7 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
   properties[PROP_QUANTIZER] =
       g_param_spec_uint ("quantizer", "Constant quantizer or quality to apply",
       "Constant quantizer or quality to apply",
-      1, G_MAXUINT, 21,
+      0, 50, 21,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
       G_PARAM_STATIC_STRINGS);
 


### PR DESCRIPTION
Perform the encoder paused -> change property -> encoder playing cycle
from inside a blocking pad probe, otherwise our video source may receive
GST_FLOW_FLUSHING from gst_pad_push() and stop producing frames.