### PR TITLE
target: allow switching bitrate control mode

### DIFF
--- a/gaeguli/adaptors/bandwidthadaptor.c
+++ b/gaeguli/adaptors/bandwidthadaptor.c
@@ -41,6 +41,16 @@ gaeguli_bandwidth_stream_adaptor_new (GstElement * srtsink,
 }
 
 static void
+gaeguli_bandwidth_adaptor_on_enabled (GaeguliStreamAdaptor * adaptor)
+{
+  /* Bandwidth adaptor operates only in constant bitrate mode. */
+  gaeguli_stream_adaptor_signal_encoding_parameters (adaptor,
+      GAEGULI_ENCODING_PARAMETER_RATECTRL,
+      GAEGULI_TYPE_VIDEO_BITRATE_CONTROL, GAEGULI_VIDEO_BITRATE_CONTROL_CBR,
+      NULL);
+}
+
+static void
 gaeguli_bandwidth_adaptor_on_stats (GaeguliStreamAdaptor * adaptor,
     GstStructure * stats)
 {
@@ -143,6 +153,7 @@ gaeguli_bandwidth_stream_adaptor_class_init (GaeguliBandwidthStreamAdaptorClass
       GAEGULI_STREAM_ADAPTOR_CLASS (klass);
 
   gobject_class->constructed = gaeguli_bandwidth_stream_adaptor_constructed;
+  streamadaptor_class->on_enabled = gaeguli_bandwidth_adaptor_on_enabled;
   streamadaptor_class->on_stats = gaeguli_bandwidth_adaptor_on_stats;
   streamadaptor_class->on_baseline_update =
       gaeguli_bandwidth_adaptor_on_baseline_update;

--- a/gaeguli/streamadaptor.c
+++ b/gaeguli/streamadaptor.c
@@ -196,7 +196,14 @@ gaeguli_stream_adaptor_set_property (GObject * object, guint property_id,
       break;
     case PROP_ENABLED:
       if (g_value_get_boolean (value)) {
+        GaeguliStreamAdaptorClass *klass =
+            GAEGULI_STREAM_ADAPTOR_GET_CLASS (self);
+
         gaeguli_stream_adaptor_start_timer (self);
+
+        if (klass->on_enabled) {
+          klass->on_enabled (self);
+        }
       } else if (priv->stats_timeout_id) {
         gaeguli_stream_adaptor_stop_timer (self);
 

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -42,6 +42,7 @@ struct _GaeguliStreamAdaptorClass
 {
   GObjectClass parent_class;
 
+  void      (* on_enabled)               (GaeguliStreamAdaptor * self);
   void      (* on_stats)                 (GaeguliStreamAdaptor * self,
                                           GstStructure * stats);
   void      (* on_baseline_update)       (GaeguliStreamAdaptor * self,

--- a/gaeguli/streamadaptor.h
+++ b/gaeguli/streamadaptor.h
@@ -31,6 +31,8 @@ G_BEGIN_DECLS
 #define GAEGULI_ENCODING_PARAMETER_BITRATE "bitrate"
 /* Constant quantizer to apply */
 #define GAEGULI_ENCODING_PARAMETER_QUANTIZER "quantizer"
+/* Rate control mode from GaeguliRateControlMode */
+#define GAEGULI_ENCODING_PARAMETER_RATECTRL "bitrate-control"
 
 #define GAEGULI_TYPE_STREAM_ADAPTOR   (gaeguli_stream_adaptor_get_type ())
 G_DECLARE_DERIVABLE_TYPE (GaeguliStreamAdaptor, gaeguli_stream_adaptor, GAEGULI,

--- a/gaeguli/types.h
+++ b/gaeguli/types.h
@@ -64,6 +64,7 @@ typedef enum {
 
 typedef enum {
   GAEGULI_VIDEO_BITRATE_CONTROL_CBR = 1,
+  GAEGULI_VIDEO_BITRATE_CONTROL_CQP,
   GAEGULI_VIDEO_BITRATE_CONTROL_VBR,
 } GaeguliVideoBitrateControl;
 

--- a/tests/adaptor-demo/http-server.c
+++ b/tests/adaptor-demo/http-server.c
@@ -236,6 +236,13 @@ gaeguli_http_server_send_property (GaeguliHttpServer * self, const gchar * name,
     json_builder_add_int_value (builder, g_value_get_uint (value));
   } else if (G_VALUE_HOLDS_BOOLEAN (value)) {
     json_builder_add_boolean_value (builder, g_value_get_boolean (value));
+  } else if (G_VALUE_HOLDS_ENUM (value)) {
+    g_autoptr (GEnumClass) enum_class = g_type_class_ref (G_VALUE_TYPE (value));
+
+    const gchar *val = g_enum_get_value (enum_class,
+        g_value_get_enum (value))->value_nick;
+
+    json_builder_add_string_value (builder, val);
   }
 
   json_builder_end_object (builder);

--- a/tests/adaptor-demo/resources/index.html
+++ b/tests/adaptor-demo/resources/index.html
@@ -21,6 +21,20 @@
             <td><input type="text" id="srt-uri" class="largefont" disabled/></td>
           </tr>
           <tr>
+            <td><b>Bitrate control:</b></td>
+            <td>
+              <select id="bitrate-control">
+                <option value="cbr">Constant Bitrate</option>
+                <option value="cqp">Constant Quantizer</option>
+                <option value="vbr">Variable Bitrate</option>
+              </select>
+            </td>
+          </tr>
+          <tr>
+            <td><b>Actual bitrate control:</b></td>
+            <td><input type="text" id="bitrate-control-actual" disabled/></td>
+          </tr>
+          <tr>
             <td><b>Bitrate:</b></td>
             <td><input type="text" id="bitrate-text" disabled/> kbps</td>
             <td>
@@ -109,6 +123,9 @@
       }
       document.getElementById("adaptive-streaming").onchange = (event) => {
         demo.property("adaptive-streaming", document.getElementById("adaptive-streaming").checked)
+      }
+      document.getElementById("bitrate-control").onchange = (event) => {
+        demo.property("bitrate-control", document.getElementById("bitrate-control").value)
       }
       document.getElementById("bitrate").onchange = (event) => {
         document.getElementById("bitrate-range").value = event.target.value / 1000

--- a/tests/adaptor-demo/resources/index.html
+++ b/tests/adaptor-demo/resources/index.html
@@ -17,12 +17,14 @@
       <fieldset id="streaming-controls" disabled>
         <table>
           <tr class="largefont">
-            <td><b>SRT URI:</b></td>
-            <td><input type="text" id="srt-uri" class="largefont" disabled/></td>
+            <th>SRT URI:</th>
+            <td class="value">
+              <input type="text" id="srt-uri" class="largefont" disabled/>
+            </td>
           </tr>
           <tr>
-            <td><b>Bitrate control:</b></td>
-            <td>
+            <th>Bitrate control:</th>
+            <td class="value">
               <select id="bitrate-control">
                 <option value="cbr">Constant Bitrate</option>
                 <option value="cqp">Constant Quantizer</option>
@@ -31,12 +33,22 @@
             </td>
           </tr>
           <tr>
-            <td><b>Actual bitrate control:</b></td>
-            <td><input type="text" id="bitrate-control-actual" disabled/></td>
+            <th>Actual bitrate control:</th>
+            <td class="value">
+              <select id="bitrate-control-actual" class="displayonly" disabled>
+                <option value=""></option>
+                <option value="cbr">Constant Bitrate</option>
+                <option value="cqp">Constant Quantizer</option>
+                <option value="vbr">Variable Bitrate</option>
+              </select>
+            </td>
           </tr>
           <tr>
-            <td><b>Bitrate:</b></td>
-            <td><input type="text" id="bitrate-text" disabled/> kbps</td>
+            <th>Bitrate:</th>
+            <td class="value">
+              <input type="text" id="bitrate-text" disabled/>
+            </td>
+            <td>kbps</td>
             <td>
               <input type="range" id="bitrate-range" min="1" max="20000"/>
               <input type="hidden" id="bitrate"/>
@@ -44,59 +56,78 @@
             <td><button type="button" id="bitrate-submit">Submit</button></td>
           </tr>
           <tr>
-            <td><b>Actual bitrate:</b></td>
-            <td>
-              <input type="text" id="bitrate-actual-text" disabled/> kbps
+            <th>Actual bitrate:</th>
+            <td class="value">
+              <input type="text" id="bitrate-actual-text" disabled/>
               <input type="hidden" id="bitrate-actual"/>
             </td>
+            <td>kbps</td>
           </tr>
           <tr>
-            <td><b>Quantizer:</b></td>
-            <td><input type="text" id="quantizer-text" disabled/></td>
+            <th>Quantizer:</th>
+            <td class="value">
+              <input type="text" id="quantizer-text" disabled/>
+            </td>
+            <td></td>
             <td><input type="range" id="quantizer" min="0" max="50"/></td>
             <td><button type="button" id="quantizer-submit">Submit</button></td>
           </tr>
           <tr>
-            <td><b>Actual quantizer:</b></td>
-            <td><input type="text" id="quantizer-actual" disabled></td>
+            <th>Actual quantizer:</th>
+            <td class="value">
+              <input type="text" id="quantizer-actual" disabled>
+            </td>
           </tr>
           <tr>
-            <td><b>SRT packets sent:</b></td>
-            <td><input type="text" id="srt-packets-sent" disabled/></td>
+            <th>SRT packets sent:</th>
+            <td class="value">
+              <input type="text" id="srt-packets-sent" disabled/>
+            </td>
           </tr>
           <tr>
-            <td><b>SRT lost packets:</b></td>
-            <td><input type="text" id="srt-packets-sent-lost" disabled/></td>
+            <th>SRT lost packets:</th>
+            <td class="value">
+              <input type="text" id="srt-packets-sent-lost" disabled/>
+            </td>
           </tr>
           <tr>
-            <td><b>SRT send rate:</b></td>
-            <td>
-              <input type="text" id="srt-send-rate-text" disabled/> kbps
+            <th>SRT send rate:</th>
+            <td class="value">
+              <input type="text" id="srt-send-rate-text" disabled/>
               <input type="hidden" id="srt-send-rate"/>
             </td>
+            <td>kbps</td>
           </tr>
           <tr>
-            <td><b>SRT measured bandwidth:</b></td>
-            <td>
-              <input type="text" id="srt-bandwidth-text" disabled/> kbps
+            <th>SRT measured bandwidth:</th>
+            <td class="value">
+              <input type="text" id="srt-bandwidth-text" disabled/>
               <input type="hidden" id="srt-bandwidth"/>
+            </td>
+            <td>kbps</td>
+          </tr>
+        </table>
+        <table>
+          <tr>
+            <th>Adaptive streaming:</th>
+            <td>
+              <input type="checkbox" id="adaptive-streaming"/>
             </td>
           </tr>
         </table>
         <table>
           <tr>
-            <td><b>Adaptive streaming:</b></td>
-            <td><input type="checkbox" id="adaptive-streaming"/></td>
-          </tr>
-        </table>
-        <table>
-          <tr>
-            <td><b>Traffic control:</b></td>
-            <td><input type="checkbox" id="tc-enabled"/></td>
+            <th>Traffic control:</th>
+            <td>
+              <input type="checkbox" id="tc-enabled"/>
+            </td>
           </tr>
           <tr>
-            <td><b>Bandwidth limit:</b></td>
-            <td><input type="text" id="tc-bandwidth-text" disabled/> kbps</td>
+            <th>Bandwidth limit:</th>
+            <td class="value">
+              <input type="text" id="tc-bandwidth-text" disabled/>
+            </td>
+            <td>kbps</td>
             <td>
               <input type="range" id="tc-bandwidth-range" min="256" max="20000"/>
               <input type="hidden" id="tc-bandwidth"/>

--- a/tests/adaptor-demo/resources/style.css
+++ b/tests/adaptor-demo/resources/style.css
@@ -25,6 +25,23 @@ input:disabled {
   background: transparent;
 }
 
+th {
+  text-align: left;
+}
+
+td.value {
+  text-align: right;
+}
+
+select.displayonly {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: blue;
+  font-size: 14px;
+  text-align: right;
+}
+
 .largefont {
   font-size: 20px;
 }


### PR DESCRIPTION
Supports CBR, VBR and constant quantizer modes with `x264enc` and `x265enc`.

Adaptor demo panel now allows switching rate control mode. Note that bandwidth stream adaptor forces CBR mode, so one has to turn adaptive streaming off in order to use VBR or CQP.