### PR TITLE
target: don't block waiting for SRT caller

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -54,6 +54,6 @@
 
 #define GAEGULI_PIPELINE_MUXSINK_STR    "\
         mpegtsmux name=muxsink_first ! tsparse set-timestamps=1 smoothing-latency=1000 ! \
-        srtsink name=sink uri=%s"
+        srtsink name=sink uri=%s wait-for-connection=false"
 
 #endif // __GAEGULI_INTERNAL_H__


### PR DESCRIPTION
In listener mode, first packet arriving to srtsink would block the
respective target's pipeline until some caller connected. Since Gaeguli
is live-streaming, video frames for which we don't have a recipient
should get dropped rather than pile up in queues, increasing latency.