### PR TITLE
target: remove gaeguli_target_get_bytes_sent()

### DIFF
--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -1069,26 +1069,6 @@ gaeguli_target_link_with_pad (GaeguliTarget * self, GstPad * pad)
       GST_PAD_PROBE_TYPE_BLOCK, _link_probe_cb, self, NULL);
 }
 
-guint64
-gaeguli_target_get_bytes_sent (GaeguliTarget * self)
-{
-  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
-
-  g_autoptr (GstStructure) s = NULL;
-  guint64 result = 0;
-
-  g_return_val_if_fail (GAEGULI_IS_TARGET (self), GAEGULI_RETURN_FAIL);
-
-  if (priv->srtsink) {
-    g_object_get (priv->srtsink, "stats", &s, NULL);
-    gst_structure_get_uint64 (s, "bytes-sent", &result);
-  } else {
-    g_warning ("SRT sink for target %d not found", self->id);
-  }
-
-  return result;
-}
-
 static gboolean
 _unlink_finish_in_main_thread (GaeguliTarget * self)
 {

--- a/gaeguli/target.h
+++ b/gaeguli/target.h
@@ -66,16 +66,6 @@ void                    gaeguli_target_link_with_pad (GaeguliTarget        *self
 
 void                    gaeguli_target_unlink        (GaeguliTarget        *self);
 
-/**
- * gaeguli_pipeline_target_get_bytes_sent:
- * @self: a #GaeguliPipeline object
- * @target_id: a SRT target as returned by #gaeguli_pipeline_add_srt_target
- *
- * Returns: the number of bytes sent over the given SRT target
- */
-guint64                 gaeguli_target_get_bytes_sent (GaeguliTarget       *self);
-
-
 GVariant               *gaeguli_target_get_stats      (GaeguliTarget       *self);
 
 G_END_DECLS

--- a/tests/test-pipeline.c
+++ b/tests/test-pipeline.c
@@ -151,14 +151,22 @@ add_remove_target_cb (AddRemoveTestData * data)
   /* Check that all targets are in NORMAL state and data are being read. */
   for (i = 0; i != G_N_ELEMENTS (data->targets); ++i) {
     TargetTestData *target = &data->targets[i];
-    guint64 bytes_sent;
+    g_autoptr (GVariant) variant = NULL;
+    guint64 bytes_sent = 0;
     g_autoptr (GError) error = NULL;
 
     if (target->target == NULL || target->closing) {
       continue;
     }
 
-    bytes_sent = gaeguli_target_get_bytes_sent (target->target);
+    variant = gaeguli_target_get_stats (target->target);
+    if (variant) {
+      GVariantDict dict;
+
+      g_variant_dict_init (&dict, variant);
+      g_variant_dict_lookup (&dict, "bytes-sent", "t", &bytes_sent);
+      g_variant_dict_clear (&dict);
+    }
 
     g_debug ("Target %u has sent %lu B", target->target->id, bytes_sent);
 


### PR DESCRIPTION
The method is only used in tests and we can obtain the value from
gaeguli_target_get_stats().