### PR TITLE
pipeline: refactor setting resolution and framerate

### DIFF
--- a/gaeguli/pipeline.h
+++ b/gaeguli/pipeline.h
@@ -56,6 +56,8 @@ GaeguliPipeline        *gaeguli_pipeline_new    (void);
  * gaeguli_pipeline_new_full:
  * @source: the source of the video
  * @device: the device used as source in case of V4L
+ * @resolution: source stream resolution
+ * @framerate: source stream frame rate
  *
  * Creates a new #GaeguliPipeline object using specific parameters.
  *
@@ -63,7 +65,9 @@ GaeguliPipeline        *gaeguli_pipeline_new    (void);
  */
 GaeguliPipeline        *gaeguli_pipeline_new_full
                                                 (GaeguliVideoSource     source,
-                                                 const gchar           *device);
+                                                 const gchar           *device,
+                                                 GaeguliVideoResolution resolution,
+                                                 guint                  framerate);
 /**
  * gaeguli_pipeline_add_srt_target:
  * @self: a #GaeguliPipeline object
@@ -86,8 +90,6 @@ GaeguliTarget          *gaeguli_pipeline_add_srt_target
  * gaeguli_pipeline_add_srt_target_full:
  * @self: a #GaeguliPipeline object
  * @codec: codec to use for streaming
- * @resolution: resolution to use for streaming
- * @framerate: framerate to use for streaming
  * @bitrate: bitrate use for streaming
  * @username: SRT Stream ID User Name identifying this target
  * @uri: SRT URI
@@ -101,8 +103,6 @@ GaeguliTarget          *gaeguli_pipeline_add_srt_target
 GaeguliTarget          *gaeguli_pipeline_add_srt_target_full
                                                 (GaeguliPipeline       *self,
                                                  GaeguliVideoCodec      codec,
-                                                 GaeguliVideoResolution resolution,
-                                                 guint                  framerate,
                                                  guint                  bitrate,
                                                  const gchar           *uri,
                                                  const gchar           *username,

--- a/meson.build
+++ b/meson.build
@@ -52,8 +52,6 @@ cdata.set('DEFAULT_VIDEO_BITRATE', 1000000)
 cdata.set('DEFAULT_VIDEO_CODEC', 'GAEGULI_VIDEO_CODEC_H264_X264')
 
 cdata.set('_GAEGULI_EXTERN', '__attribute__((visibility("default"))) extern')
-cdata.set('LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))
-
 
 configure_file(output : 'config.h', configuration : cdata)
 

--- a/tests/adaptor-demo/adaptor-demo.c
+++ b/tests/adaptor-demo/adaptor-demo.c
@@ -148,8 +148,7 @@ gaeguli_adaptor_demo_on_msg_stream (GaeguliAdaptorDemo * self, JsonObject * msg)
       }
 
       self->target = gaeguli_pipeline_add_srt_target_full (self->pipeline,
-          codec, GAEGULI_VIDEO_RESOLUTION_1920X1080, 24, 2048000,
-          "srt://:7001?mode=listener", NULL, &error);
+          codec, 2048000, "srt://:7001?mode=listener", NULL, &error);
 
       if (error) {
         g_printerr ("Unable to add SRT target: %s\n", error->message);
@@ -255,7 +254,7 @@ gaeguli_adaptor_demo_constructed (GObject * object)
   g_autoptr (GError) error = NULL;
 
   self->pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_V4L2SRC,
-      self->device);
+      self->device, GAEGULI_VIDEO_RESOLUTION_1920X1080, 24);
   self->http_server = gaeguli_http_server_new ();
 
   g_object_set (self->pipeline, "stream-adaptor",

--- a/tests/test-adaptor.c
+++ b/tests/test-adaptor.c
@@ -296,13 +296,12 @@ test_gaeguli_adaptor_stats ()
   g_autoptr (GstElement) receiver = NULL;
   g_autoptr (GError) error = NULL;
 
-  pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+  pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 15);
   g_object_set (pipeline, "stream-adaptor", GAEGULI_TYPE_TEST_ADAPTOR, NULL);
 
   gaeguli_pipeline_add_srt_target_full (pipeline, GAEGULI_VIDEO_CODEC_H264_X264,
-      GAEGULI_VIDEO_RESOLUTION_640X480, 15, TEST_BITRATE2,
-      "srt://127.0.0.1:1111", NULL, &error);
+      TEST_BITRATE2, "srt://127.0.0.1:1111", NULL, &error);
   g_assert_no_error (error);
 
   receiver = gaeguli_tests_create_receiver (GAEGULI_SRT_MODE_LISTENER, 1111,

--- a/tests/test-pipeline.c
+++ b/tests/test-pipeline.c
@@ -76,7 +76,8 @@ test_gaeguli_pipeline_instance (TestFixture * fixture, gconstpointer unused)
 {
   GaeguliTarget *target;
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   g_autoptr (GError) error = NULL;
 
   g_signal_connect (pipeline, "stream-started", G_CALLBACK (_stream_started_cb),
@@ -85,8 +86,8 @@ test_gaeguli_pipeline_instance (TestFixture * fixture, gconstpointer unused)
       fixture);
 
   target = gaeguli_pipeline_add_srt_target_full (pipeline,
-      GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-      2048000, "srt://127.0.0.1:1111", NULL, &error);
+      GAEGULI_VIDEO_CODEC_H264_X264, 2048000, "srt://127.0.0.1:1111", NULL,
+      &error);
 
   g_assert_nonnull (target);
   g_assert_cmpuint (target->id, !=, 0);
@@ -137,8 +138,7 @@ add_remove_target_cb (AddRemoveTestData * data)
           data->fixture->port_base + i);
 
       target->target = gaeguli_pipeline_add_srt_target_full (data->pipeline,
-          GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-          2048000, uri, NULL, &error);
+          GAEGULI_VIDEO_CODEC_H264_X264, 2048000, uri, NULL, &error);
       g_assert_no_error (error);
 
       g_debug ("Added target %u", target->target->id);
@@ -231,8 +231,8 @@ test_gaeguli_pipeline_add_remove_target_random (TestFixture * fixture,
 
   g_mutex_init (&data.lock);
   data.fixture = fixture;
-  data.pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+  data.pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC,
+      NULL, GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   data.targets_to_create = 10;
 
   g_signal_connect (data.pipeline, "stream-stopped",
@@ -250,19 +250,20 @@ static void
 test_gaeguli_pipeline_address_in_use (void)
 {
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   g_autoptr (GError) error = NULL;
   GaeguliTarget *target;
 
   target = gaeguli_pipeline_add_srt_target_full (pipeline,
-      GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-      2048000, "srt://127.0.0.1:1111?mode=listener", NULL, &error);
+      GAEGULI_VIDEO_CODEC_H264_X264, 2048000,
+      "srt://127.0.0.1:1111?mode=listener", NULL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (target);
 
   target = gaeguli_pipeline_add_srt_target_full (pipeline,
-      GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-      2048000, "srt://127.0.0.2:1111?mode=listener", NULL, &error);
+      GAEGULI_VIDEO_CODEC_H264_X264, 2048000,
+      "srt://127.0.0.2:1111?mode=listener", NULL, &error);
   g_assert_error (error, GAEGULI_TRANSMIT_ERROR,
       GAEGULI_TRANSMIT_ERROR_ADDRINUSE);
   g_assert_null (target);
@@ -335,8 +336,7 @@ receiver1_buffer_cb (GstElement * object, GstBuffer * buffer, GstPad * pad,
         data->fixture->port_base + 1);
 
     target = gaeguli_pipeline_add_srt_target_full (data->pipeline,
-        GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-        2048000, uri_str, NULL, &error);
+        GAEGULI_VIDEO_CODEC_H264_X264, 2048000, uri_str, NULL, &error);
     g_assert_no_error (error);
     g_assert_nonnull (target);
 
@@ -349,7 +349,8 @@ static void
 test_gaeguli_pipeline_listener (TestFixture * fixture, gconstpointer unused)
 {
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   g_autoptr (GError) error = NULL;
   g_autofree gchar *uri_str = NULL;
   ClientTestData data = { 0 };
@@ -358,8 +359,7 @@ test_gaeguli_pipeline_listener (TestFixture * fixture, gconstpointer unused)
   uri_str = g_strdup_printf ("srt://127.0.0.1:%d?mode=caller",
       fixture->port_base);
   target = gaeguli_pipeline_add_srt_target_full (pipeline,
-      GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-      2048000, uri_str, NULL, &error);
+      GAEGULI_VIDEO_CODEC_H264_X264, 2048000, uri_str, NULL, &error);
   g_assert_no_error (error);
   g_assert_nonnull (target);
 
@@ -404,8 +404,7 @@ listener_random_cb (ListenerRandomTestData * data)
         data->fixture->port_base + i);
 
     data->listeners[i] = gaeguli_pipeline_add_srt_target_full (data->pipeline,
-        GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 30,
-        2048000, uri, NULL, &error);
+        GAEGULI_VIDEO_CODEC_H264_X264, 2048000, uri, NULL, &error);
     g_assert_no_error (error);
 
     --data->listeners_to_create;
@@ -436,7 +435,8 @@ test_gaeguli_pipeline_listener_random (TestFixture * fixture,
     gconstpointer unused)
 {
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
 
   ListenerRandomTestData data = { 0 };
   guint timeout_source;
@@ -492,7 +492,8 @@ test_gaeguli_pipeline_connection_error (TestFixture * fixture,
 {
   ConnectionErrorTestData data;
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   g_autoptr (GstElement) receiver = NULL;
   g_autoptr (GError) error = NULL;
   g_autofree gchar *uri = NULL;
@@ -553,11 +554,11 @@ static void
 do_pipeline_cycle (TestFixture * fixture, GaeguliVideoCodec codec)
 {
   g_autoptr (GaeguliPipeline) pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 30);
   g_autoptr (GError) error = NULL;
 
-  gaeguli_pipeline_add_srt_target_full (pipeline, codec,
-      GAEGULI_VIDEO_RESOLUTION_640X480, 30, 2048000,
+  gaeguli_pipeline_add_srt_target_full (pipeline, codec, 2048000,
       "srt://127.0.0.1:1111", NULL, &error);
 
   fixture->pipeline = pipeline;

--- a/tests/test-target.c
+++ b/tests/test-target.c
@@ -33,12 +33,12 @@ test_gaeguli_target_encoding_params ()
   GaeguliTarget *target;
   guint val;
 
-  pipeline =
-      gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL);
+  pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC, NULL,
+      GAEGULI_VIDEO_RESOLUTION_640X480, 15);
 
   target = gaeguli_pipeline_add_srt_target_full (pipeline,
-      GAEGULI_VIDEO_CODEC_H264_X264, GAEGULI_VIDEO_RESOLUTION_640X480, 15,
-      DEFAULT_BITRATE, "srt://127.0.0.1:1111", NULL, &error);
+      GAEGULI_VIDEO_CODEC_H264_X264, DEFAULT_BITRATE, "srt://127.0.0.1:1111",
+      NULL, &error);
   g_assert_no_error (error);
 
   g_object_get (target, "bitrate", &val, NULL);

--- a/tools/pipeline.c
+++ b/tools/pipeline.c
@@ -122,7 +122,8 @@ main (int argc, char *argv[])
     return -1;
   }
 
-  pipeline = gaeguli_pipeline_new_full (DEFAULT_VIDEO_SOURCE, options.device);
+  pipeline = gaeguli_pipeline_new_full (DEFAULT_VIDEO_SOURCE, options.device,
+      DEFAULT_VIDEO_RESOLUTION, DEFAULT_VIDEO_FRAMERATE);
   g_object_set (pipeline, "clock-overlay", options.overlay, NULL);
 
   signal_watch_intr_id =


### PR DESCRIPTION
Those aren't properties of a target, but of its pipeline. Move resolution and framerate parameters from ..._add_srt_target_full() to pipeline constructor.

