### PR TITLE
target: use vaapipostproc instead of videoconvert

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -49,11 +49,11 @@
         omxh264enc name=enc insert-sps-pps=true insert-vui=true control-rate=1 periodicity-idr=%d ! queue "
 
 #define GAEGULI_PIPELINE_VAAPI_H264_STR    "\
-        queue name=enc_first ! videoconvert ! vaapih264enc name=enc keyframe-period=%d ! \
+        queue name=enc_first ! vaapipostproc ! vaapih264enc name=enc keyframe-period=%d ! \
         h264parse ! queue "
 
 #define GAEGULI_PIPELINE_VAAPI_H265_STR    "\
-        queue name=enc_first ! videoconvert ! vaapih265enc name=enc keyframe-period=%d ! \
+        queue name=enc_first ! vaapipostproc ! vaapih265enc name=enc keyframe-period=%d ! \
         h265parse ! queue "
 
 #define GAEGULI_PIPELINE_MUXSINK_STR    "\


### PR DESCRIPTION
Lowers pipeline CPU usage.