### PR TITLE
pipeline: keep pipeline alive throughout async removal of GaeguliTarget

### DIFF
--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -549,6 +549,9 @@ gaeguli_pipeline_emit_stream_stopped (GaeguliPipeline * self,
     g_mutex_lock (&self->lock);
   }
   g_mutex_unlock (&self->lock);
+
+  /* Reference acquired in gaeguli_pipeline_remove_target(). */
+  g_object_unref (self);
 }
 
 GaeguliTarget *
@@ -641,6 +644,11 @@ gaeguli_pipeline_remove_target (GaeguliPipeline * self, GaeguliTarget * target,
   }
 
   gaeguli_target_unlink (target);
+  if (gaeguli_target_get_state (target) == GAEGULI_TARGET_STATE_STOPPING) {
+    /* Target removal will happen asynchronously. Keep the pipeline alive
+     * until the target fires "stream-stopped". */
+    g_object_ref (self);
+  }
   g_object_unref (target);
 
 out:

--- a/gaeguli/target.h
+++ b/gaeguli/target.h
@@ -66,6 +66,8 @@ void                    gaeguli_target_start         (GaeguliTarget        *self
 
 void                    gaeguli_target_unlink        (GaeguliTarget        *self);
 
+GaeguliTargetState      gaeguli_target_get_state     (GaeguliTarget        *self);
+
 GVariant               *gaeguli_target_get_stats      (GaeguliTarget       *self);
 
 G_END_DECLS

--- a/gaeguli/types.h
+++ b/gaeguli/types.h
@@ -87,6 +87,15 @@ typedef enum {
   GAEGULI_SRT_KEY_LENGTH_32 = 32
 } GaeguliSRTKeyLength;
 
+typedef enum {
+  GAEGULI_TARGET_STATE_NEW,
+  GAEGULI_TARGET_STATE_STARTING,
+  GAEGULI_TARGET_STATE_RUNNING,
+  GAEGULI_TARGET_STATE_STOPPING,
+  GAEGULI_TARGET_STATE_STOPPED,
+  GAEGULI_TARGET_STATE_ERROR
+} GaeguliTargetState;
+
 #define GAEGULI_RESOURCE_ERROR          (gaeguli_resource_error_quark ())
 GQuark gaeguli_resource_error_quark     (void);
 


### PR DESCRIPTION
Fixes races in HwangsaeRelay test suite.

