### PR TITLE
pipeline: reduce pcr-interval of mpegtsmux

### DIFF
--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -643,6 +643,7 @@ gaeguli_target_initable_init (GInitable * initable, GCancellable * cancellable,
 
   g_autoptr (GaeguliPipeline) owner = NULL;
   g_autoptr (GstElement) enc_first = NULL;
+  g_autoptr (GstElement) muxsink_first = NULL;
   g_autoptr (GstPad) enc_sinkpad = NULL;
   g_autofree gchar *pipeline_str = NULL;
   g_autofree gchar *uri_str = NULL;
@@ -676,6 +677,14 @@ gaeguli_target_initable_init (GInitable * initable, GCancellable * cancellable,
   }
 
   gst_object_ref_sink (self->pipeline);
+
+  muxsink_first =
+      gst_bin_get_by_name (GST_BIN (self->pipeline), "muxsink_first");
+  if (g_object_class_find_property (G_OBJECT_GET_CLASS (muxsink_first),
+          "pcr-interval")) {
+    g_info ("set pcr-interval to 360");
+    g_object_set (G_OBJECT (muxsink_first), "pcr-interval", 360, NULL);
+  }
 
   priv->srtsink = gst_bin_get_by_name (GST_BIN (self->pipeline), "sink");
   g_object_set_data (G_OBJECT (priv->srtsink), "gaeguli-target-id",


### PR DESCRIPTION
The default interval is around 40 milliseconds(3600 in 90kHz).
Since a receiver needs 2 or 3 PCRs in MPEG-TS stream for
smoothe demuxing, it is necessary to shorten the PCR interval
on the sending side.