### PR TITLE
pipeline: network benchmarking

### DIFF
--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -1277,6 +1277,18 @@ out:
   return g_variant_dict_end (dict);
 }
 
+GaeguliSRTMode
+gaeguli_target_get_srt_mode (GaeguliTarget * self)
+{
+  GaeguliTargetPrivate *priv = gaeguli_target_get_instance_private (self);
+
+  GaeguliSRTMode mode;
+
+  g_object_get (priv->srtsink, "mode", &mode, NULL);
+
+  return mode;
+}
+
 GaeguliTargetState
 gaeguli_target_get_state (GaeguliTarget * self)
 {

--- a/gaeguli/target.h
+++ b/gaeguli/target.h
@@ -70,6 +70,9 @@ GaeguliTargetState      gaeguli_target_get_state     (GaeguliTarget        *self
 
 GaeguliSRTMode          gaeguli_target_get_srt_mode  (GaeguliTarget        *self);
 
+const gchar            *gaeguli_target_get_peer_address
+                                                     (GaeguliTarget        *self);
+
 GVariant               *gaeguli_target_get_stats      (GaeguliTarget       *self);
 
 G_END_DECLS

--- a/gaeguli/target.h
+++ b/gaeguli/target.h
@@ -68,6 +68,8 @@ void                    gaeguli_target_unlink        (GaeguliTarget        *self
 
 GaeguliTargetState      gaeguli_target_get_state     (GaeguliTarget        *self);
 
+GaeguliSRTMode          gaeguli_target_get_srt_mode  (GaeguliTarget        *self);
+
 GVariant               *gaeguli_target_get_stats      (GaeguliTarget       *self);
 
 G_END_DECLS


### PR DESCRIPTION
Periodically collects bandwidth estimate and RTT from SRT statistics. The benchmark is gathered for each peer IP address.

Needs https://github.com/hwangsaeul/gst-plugins-bad/pull/7.