### PR TITLE
Set buffer sizes

### DIFF
--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -57,6 +57,7 @@ typedef struct
   GaeguliSRTKeyLength pbkeylen;
   GType adaptor_type;
   gboolean adaptive_streaming;
+  gint32 buffer_size;
 } GaeguliTargetPrivate;
 
 enum
@@ -77,6 +78,7 @@ enum
   PROP_PBKEYLEN,
   PROP_ADAPTOR_TYPE,
   PROP_ADAPTIVE_STREAMING,
+  PROP_BUFFER_SIZE,
   PROP_LAST
 };
 
@@ -813,6 +815,9 @@ gaeguli_target_get_property (GObject * object,
       }
       g_value_set_boolean (value, priv->adaptive_streaming);
       break;
+    case PROP_BUFFER_SIZE:
+      g_value_set_int (value, priv->buffer_size);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -895,6 +900,9 @@ gaeguli_target_set_property (GObject * object,
       }
       break;
     }
+    case PROP_BUFFER_SIZE:
+      priv->buffer_size = g_value_get_int (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -1021,6 +1029,11 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY |
       G_PARAM_STATIC_STRINGS);
 
+  properties[PROP_BUFFER_SIZE] =
+      g_param_spec_int ("buffer-size", "Send buffer size",
+      "Send buffer size in bytes (0 = library default)", 0, G_MAXINT32, 0,
+      G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS);
+
   g_object_class_install_properties (gobject_class, G_N_ELEMENTS (properties),
       properties);
 
@@ -1126,7 +1139,7 @@ gaeguli_target_start (GaeguliTarget * self, GError ** error)
   }
 
   g_object_set (priv->srtsink, "passphrase", priv->passphrase, "pbkeylen",
-      pbkeylen, NULL);
+      pbkeylen, "buffer-size", priv->buffer_size, NULL);
 
   if (priv->state != GAEGULI_TARGET_STATE_NEW) {
     g_warning ("Target %u is already running", self->id);

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -79,6 +79,7 @@ enum
   PROP_ADAPTOR_TYPE,
   PROP_ADAPTIVE_STREAMING,
   PROP_BUFFER_SIZE,
+  PROP_LATENCY,
   PROP_LAST
 };
 
@@ -818,6 +819,10 @@ gaeguli_target_get_property (GObject * object,
     case PROP_BUFFER_SIZE:
       g_value_set_int (value, priv->buffer_size);
       break;
+    case PROP_LATENCY:{
+      g_object_get_property (G_OBJECT (priv->srtsink), "latency", value);
+      break;
+    }
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -1033,6 +1038,11 @@ gaeguli_target_class_init (GaeguliTargetClass * klass)
       g_param_spec_int ("buffer-size", "Send buffer size",
       "Send buffer size in bytes (0 = library default)", 0, G_MAXINT32, 0,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_LATENCY] =
+      g_param_spec_int ("latency", "SRT latency",
+      "SRT latency in milliseconds", 0, G_MAXINT32, 0,
+      G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (gobject_class, G_N_ELEMENTS (properties),
       properties);

--- a/gaeguli/target.c
+++ b/gaeguli/target.c
@@ -1124,6 +1124,11 @@ gaeguli_target_create_streamid (GaeguliTarget * self)
     g_string_append_printf (str, "u=%s", priv->username);
   }
 
+  if (priv->buffer_size > 0) {
+    g_string_append_printf (str, "%sh8l_bufsize=%d",
+        (str->len > 0) ? "," : "", priv->buffer_size);
+  }
+
   if (str->len > 0) {
     g_string_prepend (str, "#!::");
   }


### PR DESCRIPTION
From the collected benchmarks, calculate the optimal size of send and receive buffers for the particular target IP address. Set `SRTO_SNDBUF` locally and add a custom key `h8l_bufsize` into STREAMID, which a compatible receiver can use to set its receive buffer.


Requires https://github.com/hwangsaeul/gaeguli/pull/117
Requires https://github.com/hwangsaeul/gst-plugins-bad/pull/8