### PR TITLE
pipeline: add API for still image capture

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -29,6 +29,9 @@
 #define GAEGULI_PIPELINE_VSRC_STR       "\
         %s ! capsfilter name=caps ! %s ! tee name=tee allow-not-linked=1 "
 
+#define GAEGULI_PIPELINE_IMAGE_STR    "\
+        valve name=valve drop=1 ! jpegenc ! fakesink name=fakesink async=0"
+
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency key-int-max=%d ! \
         h264parse ! queue "

--- a/gaeguli/pipeline.h
+++ b/gaeguli/pipeline.h
@@ -24,7 +24,7 @@
 #error "Only <gaeguli/gaeguli.h> can be included directly."
 #endif
 
-#include <glib-object.h>
+#include <gio/gio.h>
 #include <gaeguli/types.h>
 
 typedef struct _GaeguliTarget GaeguliTarget;
@@ -121,6 +121,37 @@ GaeguliTarget          *gaeguli_pipeline_add_srt_target_full
 GaeguliReturn           gaeguli_pipeline_remove_target
                                                 (GaeguliPipeline       *self,
                                                  GaeguliTarget         *target,
+                                                 GError               **error);
+
+/**
+ * gaeguli_pipeline_create_snapshot_async:
+ * @self: a #GaeguliPipeline object
+ * @cancellable: a #GCancellable object
+ * @callback: a #GAsyncReadyCallback to call when the request is fulfilled
+ * @user_data: arbitrary data passed to @callback
+ *
+ * Asynchronously saves a single video frame as JPEG image and passes it to
+ * @callback.
+ */
+void                    gaeguli_pipeline_create_snapshot_async
+                                                (GaeguliPipeline       *self,
+                                                 GCancellable          *cancellable,
+                                                 GAsyncReadyCallback    callback,
+                                                 gpointer               user_data);
+
+/**
+ * gaeguli_pipeline_create_snapshot_finish:
+ * @self: a #GaeguliPipeline object
+ * @result: a #GAsyncResult obtained from the GAsyncReadyCallback passed to gaeguli_pipeline_create_snapshot_async()
+ * @error: Return location for error or %NULL.
+ *
+ * Finishes an operation started with gaeguli_pipeline_create_snapshot_async().
+ *
+ * Returns: #GBytes with JPEG image data. On error returns %NULL and sets @error.
+ */
+GBytes                 *gaeguli_pipeline_create_snapshot_finish
+                                                (GaeguliPipeline       *self,
+                                                 GAsyncResult          *result,
                                                  GError               **error);
 
 /**

--- a/gaeguli/types.h
+++ b/gaeguli/types.h
@@ -104,6 +104,7 @@ typedef enum {
   GAEGULI_RESOURCE_ERROR_READ,
   GAEGULI_RESOURCE_ERROR_WRITE,
   GAEGULI_RESOURCE_ERROR_RW,
+  GAEGULI_RESOURCE_ERROR_STOPPED,
 } GaeguliResourceError;
 
 #define GAEGULI_TRANSMIT_ERROR          (gaeguli_transmit_error_quark ())


### PR DESCRIPTION
A bare bone implementation. Full version must support

* set file destination
* tag injection
* asynchronously return file and path of the created JPEG image.