### PR TITLE
pipeline: snapshot quality and EXIF tag injection

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -30,7 +30,7 @@
         %s ! capsfilter name=caps ! %s ! tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_IMAGE_STR    "\
-        valve name=valve drop=1 ! jpegenc name=jpegenc ! fakesink name=fakesink async=0"
+        valve name=valve drop=1 ! jpegenc name=jpegenc ! jifmux name=jifmux ! fakesink name=fakesink async=0"
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency key-int-max=%d ! \

--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -30,7 +30,7 @@
         %s ! capsfilter name=caps ! %s ! tee name=tee allow-not-linked=1 "
 
 #define GAEGULI_PIPELINE_IMAGE_STR    "\
-        valve name=valve drop=1 ! jpegenc ! fakesink name=fakesink async=0"
+        valve name=valve drop=1 ! jpegenc name=jpegenc ! fakesink name=fakesink async=0"
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency key-int-max=%d ! \

--- a/gaeguli/pipeline.h
+++ b/gaeguli/pipeline.h
@@ -126,6 +126,8 @@ GaeguliReturn           gaeguli_pipeline_remove_target
 /**
  * gaeguli_pipeline_create_snapshot_async:
  * @self: a #GaeguliPipeline object
+ * @tags: a #GVariant of type #G_VARIANT_TYPE_VARDICT with tags to insert
+ * into the snapshot in EXIF format.
  * @cancellable: a #GCancellable object
  * @callback: a #GAsyncReadyCallback to call when the request is fulfilled
  * @user_data: arbitrary data passed to @callback
@@ -135,6 +137,7 @@ GaeguliReturn           gaeguli_pipeline_remove_target
  */
 void                    gaeguli_pipeline_create_snapshot_async
                                                 (GaeguliPipeline       *self,
+                                                 GVariant              *tags,
                                                  GCancellable          *cancellable,
                                                  GAsyncReadyCallback    callback,
                                                  gpointer               user_data);

--- a/gaeguli/types.h
+++ b/gaeguli/types.h
@@ -96,6 +96,12 @@ typedef enum {
   GAEGULI_TARGET_STATE_ERROR
 } GaeguliTargetState;
 
+typedef enum {
+  GAEGULI_IDCT_METHOD_ISLOW = 0,
+  GAEGULI_IDCT_METHOD_IFAST = 1,
+  GAEGULI_IDCT_METHOD_FLOAT = 2
+} GaeguliIDCTMethod;
+
 #define GAEGULI_RESOURCE_ERROR          (gaeguli_resource_error_quark ())
 GQuark gaeguli_resource_error_quark     (void);
 


### PR DESCRIPTION
The pipeline can insert any tag listed in GStreamer's `gsttaglist.h` into a snapshot.