### PR TITLE
bandwidthadaptor: tune the adaptor's behavior

### DIFF
--- a/tests/test-adaptor.c
+++ b/tests/test-adaptor.c
@@ -394,23 +394,23 @@ test_gaeguli_adaptor_bandwidth ()
 
   g_assert_false (data.params_change_triggered);
 
-  /* Bandwidth lower than default - bitrate should change to 90% of available
-   * bandwidth. */
+  /* Bandwidth lower than default - bitrate should change to 120% of estimated
+   * bandwidth (because it seems libsrt estimates too low). */
 
   gaeguli_dummy_srtsink_set_stats (dummysrt, "bandwidth-mbps", G_TYPE_DOUBLE,
       0.7, NULL);
-  data.expected_bitrate = 0.7 * 0.9 * 1e6;
+  data.expected_bitrate = 0.7 * 1.2 * 1e6;
 
   g_main_loop_run (loop);
 
   g_assert_true (data.params_change_triggered);
 
-  /* Bandwidth going back up over default bitrate - bitrate should change to
-   * default. */
+  /* Bandwidth going back up over default bitrate - bitrate should begin
+   * rising in 5% increments. */
 
   gaeguli_dummy_srtsink_set_stats (dummysrt, "bandwidth-mbps", G_TYPE_DOUBLE,
       2.0, NULL);
-  data.expected_bitrate = 1000000;
+  data.expected_bitrate = data.expected_bitrate * 1.05;
 
   g_main_loop_run (loop);
 


### PR DESCRIPTION
Some changes I did to the example bandwidth adaptor while I was recording the demonstration video for H8L network adaptive streaming.

* Update current bitrate when the adaptor is re-enabled
* Set encoding bitrate a bit higher than libsrt network bandwidth
  estimate
* Don't drop the bitrate below 600 kbps
* Increase encoder bitrate in smaller steps over a longer time period.
  libsrt's network bandwidth estimates is at times far too high,
  encouraging the adaptor to reinstate full bitrate all at once, which
  only leads to a short period of broken stream before the adaptor is
  forced to throttle the bitrate again