### PR TITLE
pipeline: reintroduce image snapshots

### DIFF
--- a/gaeguli/gaeguli-internal.h
+++ b/gaeguli/gaeguli-internal.h
@@ -34,11 +34,14 @@
 
 #define GAEGULI_PIPELINE_TAG "gaeguli.pipeline_id"
 
-#define GAEGULI_PIPELINE_VSRC_STR       "\
-        %s ! capsfilter name=caps ! %s ! pipewiresink mode=provide stream-properties=%s "
+#define GAEGULI_PIPELINE_VSRC_BASE_STR    "\
+        %s ! capsfilter name=caps ! %s ! tee name=t ! pipewiresink mode=provide stream-properties=%s "
 
 #define GAEGULI_PIPELINE_IMAGE_STR    "\
-        valve name=valve drop=1 ! jpegenc name=jpegenc ! jifmux name=jifmux ! fakesink name=fakesink async=0"
+        t. ! valve name=valve drop=1 ! jpegenc name=jpegenc ! jifmux name=jifmux ! fakesink name=fakesink async=0"
+
+#define GAEGULI_PIPELINE_VSRC_STR \
+        GAEGULI_PIPELINE_VSRC_BASE_STR GAEGULI_PIPELINE_IMAGE_STR
 
 #define GAEGULI_PIPELINE_GENERAL_H264ENC_STR    "\
         pipewiresrc path=%u do-timestamp=true ! queue name=enc_first ! videoconvert ! x264enc name=enc tune=zerolatency key-int-max=%d ! \

--- a/gaeguli/pipeline.c
+++ b/gaeguli/pipeline.c
@@ -604,12 +604,7 @@ _get_vsrc_pipeline_string (GaeguliPipeline * self)
   g_autofree gchar *source = _get_source_description (self);
   g_autofree gchar *props = _get_stream_props_description (self);
 
-  /* FIXME - pipewiresink along with another sink in the pipeline   *
-   * do not provide the captured video to the consumer pipeline.    *
-   * Hence its inclusion is diabled.                                *
-   * This should be a sepearate target.                             */
-  return g_strdup_printf
-      (GAEGULI_PIPELINE_VSRC_STR, source,
+  return g_strdup_printf (GAEGULI_PIPELINE_VSRC_STR, source,
       self->source == GAEGULI_VIDEO_SOURCE_NVARGUSCAMERASRC ? "" :
       GAEGULI_PIPELINE_DECODEBIN_STR, props);
 }


### PR DESCRIPTION
Adds back possibility to save JPEG snapshots of the pipeline's stream.

This change depends on fixing a crash in pipewiresink:
https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/418